### PR TITLE
Refine dashboard and trámites UI

### DIFF
--- a/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
@@ -2,147 +2,395 @@ package ar.edu.unse.siga.ui.pages;
 
 import ar.edu.unse.siga.domain.Usuario;
 import ar.edu.unse.siga.ui.base.CardPanel;
-import ar.edu.unse.siga.ui.base.ScalableSvgPanel;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 public class HomePage extends JPanel {
 
     private final Usuario usuarioActual;
+    private final DateTimeFormatter friendlyDate = DateTimeFormatter.ofPattern("dd 'de' MMMM yyyy");
 
-    // Si hoy no pasás el usuario, podés dejar este ctor y delegar.
     public HomePage() {
         this(null);
     }
 
     public HomePage(Usuario usuarioActual) {
         this.usuarioActual = usuarioActual;
-
-        setOpaque(true);
-        setBackground(new Color(245, 249, 255));
+        setOpaque(false);
         setLayout(new BorderLayout());
 
-        // ========== HERO (igual que tenías) ==========
-        var hero = new ScalableSvgPanel("hero/home.svg");
-        hero.setMaxPadding(64);
-        add(hero, BorderLayout.NORTH);
-
-        // ========== CONTENIDO (dashboard) ==========
-        var content = new JPanel(new GridBagLayout());
-        content.setOpaque(false);
-        add(content, BorderLayout.CENTER);
+        JPanel layout = new JPanel(new GridBagLayout());
+        layout.setOpaque(false);
+        layout.setBorder(new EmptyBorder(0, 8, 8, 8));
 
         GridBagConstraints gc = new GridBagConstraints();
-        gc.insets = new Insets(8, 16, 8, 16);
-        gc.anchor = GridBagConstraints.FIRST_LINE_START;
-        gc.fill = GridBagConstraints.BOTH;
-
-        // HEADER (título + meta, como en el login)
-        var header = new JPanel(new BorderLayout());
-        header.setOpaque(false);
-        header.setBorder(BorderFactory.createEmptyBorder(6, 0, 2, 0));
-
-        var title = new JLabel("Inicio");
-        title.setFont(new Font("Segoe UI", Font.BOLD, 22));
-        header.add(title, BorderLayout.WEST);
-
-        var meta = new JLabel(
-                (usuarioActual != null ? usuarioActual.getUsuario() : "") +
-                "   |   " + LocalDate.now()
-        );
-        meta.setForeground(new Color(100, 100, 100));
-        meta.setFont(new Font("Segoe UI", Font.PLAIN, 12));
-        header.add(meta, BorderLayout.EAST);
-
-        gc.gridx = 0; gc.gridy = 0; gc.weightx = 1; gc.weighty = 0;
-        content.add(header, gc);
-
-        // ====== Fila KPI ======
-        var kpis = new JPanel(new GridLayout(1, 3, 16, 0));
-        kpis.setOpaque(false);
-        kpis.add(kpi("Inventario total", "2,345", "bienes registrados"));
-        kpis.add(kpi("Faltantes", "15", "requieren reposición"));
-        kpis.add(kpi("Expedientes abiertos", "27", "en trámite"));
+        gc.gridx = 0;
+        gc.weightx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.insets = new Insets(0, 0, 18, 0);
+        gc.gridy = 0;
+        layout.add(buildHeroSection(), gc);
 
         gc.gridy = 1;
-        content.add(kpis, gc);
-
-        // ====== Acciones rápidas ======
-        var quick = new CardPanel();
-        quick.setLayout(new FlowLayout(FlowLayout.LEFT, 12, 2));
-        quick.add(primary("Nuevo ítem",        e -> {/* TODO abrir alta inventario */}));
-        quick.add(primary("Nuevo expediente",  e -> {/* TODO abrir mesa de entrada */}));
-        quick.add(primary("Generar reporte",   e -> {/* TODO abrir reportes */}));
+        gc.insets = new Insets(0, 0, 20, 0);
+        gc.weighty = 1;
+        gc.fill = GridBagConstraints.BOTH;
+        layout.add(buildDashboardGrid(), gc);
 
         gc.gridy = 2;
-        content.add(quick, gc);
+        gc.insets = new Insets(0, 0, 0, 0);
+        gc.weighty = 0;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        layout.add(buildQuickActions(), gc);
 
-        // ====== Actividad reciente ======
-        var recent = new CardPanel();
-        recent.setLayout(new BorderLayout(8,8));
-
-        var recentTitle = new JLabel("Actividad reciente");
-        recentTitle.setFont(new Font("Segoe UI", Font.BOLD, 16));
-        recent.add(recentTitle, BorderLayout.NORTH);
-
-        String[] cols = {"Fecha/Hora","Módulo","Acción","Detalle","Usuario"};
-        Object[][] rows = {
-                {"18:02","Inventario","Alta","PC HP 400 G9","admin"},
-                {"17:51","Mesa Entrada","Derivación","Exp. 123/25 a Compras","admin"},
-                {"16:40","Inventario","Movimiento","Salida de 10 tóner","mlopez"}
-        };
-        var model = new DefaultTableModel(rows, cols) { @Override public boolean isCellEditable(int r, int c) { return false; } };
-        var table = new JTable(model);
-        table.setRowHeight(24);
-        table.setShowGrid(false);
-        table.setFillsViewportHeight(true);
-        recent.add(new JScrollPane(table), BorderLayout.CENTER);
-
-        gc.gridy = 3; gc.weighty = 1; // esta crece
-        content.add(recent, gc);
+        add(layout, BorderLayout.CENTER);
     }
 
-    // --------- helpers de UI (reusan tu CardPanel) ---------
-    private CardPanel kpi(String title, String value, String hint) {
-        var card = new CardPanel();
-        card.setLayout(new BorderLayout(8, 8));
+    private JComponent buildHeroSection() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(24, 18));
 
-        var center = new JPanel();
-        center.setOpaque(false);
-        center.setLayout(new BoxLayout(center, BoxLayout.Y_AXIS));
+        JPanel headerRow = new JPanel(new BorderLayout());
+        headerRow.setOpaque(false);
 
-        var lblTitle = new JLabel(title);
-        lblTitle.setFont(new Font("Segoe UI", Font.PLAIN, 13));
-        lblTitle.setForeground(new Color(110,110,110));
+        JPanel greetings = new JPanel();
+        greetings.setOpaque(false);
+        greetings.setLayout(new BoxLayout(greetings, BoxLayout.Y_AXIS));
+        String name = usuarioActual != null && usuarioActual.getUsuario() != null
+                ? usuarioActual.getUsuario()
+                : "Administrador";
+        JLabel greet = new JLabel("Hola " + name + ", encantado de verte.");
+        greet.setFont(new Font("Segoe UI", Font.BOLD, 24));
+        greet.setForeground(new Color(29, 55, 124));
+        JLabel sub = new JLabel("Panel de control general del sistema");
+        sub.setFont(new Font("Segoe UI", Font.PLAIN, 14));
+        sub.setForeground(new Color(110, 126, 165));
+        greetings.add(greet);
+        greetings.add(Box.createVerticalStrut(4));
+        greetings.add(sub);
 
-        var lblValue = new JLabel(value);
-        lblValue.setFont(new Font("Segoe UI", Font.BOLD, 24));
-        lblValue.setForeground(new Color(30,30,30));
+        headerRow.add(greetings, BorderLayout.CENTER);
+        headerRow.add(buildHeaderActions(), BorderLayout.EAST);
+        card.add(headerRow, BorderLayout.NORTH);
 
-        var lblHint = new JLabel(hint);
-        lblHint.setFont(new Font("Segoe UI", Font.PLAIN, 12));
-        lblHint.setForeground(new Color(130,130,130));
+        JPanel body = new JPanel();
+        body.setOpaque(false);
+        body.setLayout(new BoxLayout(body, BoxLayout.Y_AXIS));
+        body.add(alertBanner());
+        body.add(Box.createVerticalStrut(18));
+        body.add(metricsRow());
 
-        center.add(lblTitle);
-        center.add(Box.createVerticalStrut(2));
-        center.add(lblValue);
-        center.add(Box.createVerticalStrut(2));
-        center.add(lblHint);
-
-        card.add(center, BorderLayout.CENTER);
+        card.add(body, BorderLayout.CENTER);
         return card;
     }
 
-    private JButton primary(String text, java.awt.event.ActionListener onClick) {
+    private Component buildHeaderActions() {
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 12, 0));
+        actions.setOpaque(false);
+        actions.add(headerChip("Perfil"));
+        actions.add(headerChip("Notificaciones"));
+        actions.add(headerChip("Ajustes"));
+        return actions;
+    }
+
+    private JButton headerChip(String text) {
         JButton b = new JButton(text);
         b.setFocusPainted(false);
         b.setFont(new Font("Segoe UI", Font.PLAIN, 13));
-        b.putClientProperty("JButton.buttonType", "roundRect"); // FlatLaf
-        b.setPreferredSize(new Dimension(170, 36));
-        b.addActionListener(onClick);
+        b.setForeground(new Color(52, 83, 169));
+        b.setBackground(new Color(230, 238, 255));
+        b.setBorder(BorderFactory.createEmptyBorder(8, 14, 8, 14));
+        b.putClientProperty("JButton.buttonType", "roundRect");
         return b;
     }
+
+    private JComponent alertBanner() {
+        JPanel banner = new JPanel() {
+            @Override
+            protected void paintComponent(Graphics g) {
+                Graphics2D g2 = (Graphics2D) g.create();
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                GradientPaint gp = new GradientPaint(0, 0, new Color(37, 99, 235),
+                        getWidth(), getHeight(), new Color(21, 75, 204));
+                g2.setPaint(gp);
+                g2.fillRoundRect(0, 0, getWidth(), getHeight(), 20, 20);
+                g2.dispose();
+                super.paintComponent(g);
+            }
+        };
+        banner.setOpaque(false);
+        banner.setLayout(new FlowLayout(FlowLayout.LEFT, 16, 12));
+        banner.setBorder(new EmptyBorder(4, 18, 4, 18));
+
+        banner.add(alertChip("Alertas importantes"));
+        banner.add(alertMessage("Nuevo protocolo de gastos"));
+        banner.add(alertMessage("Mantenimiento del sistema de 11 PM a 2 AM"));
+        return banner;
+    }
+
+    private JLabel alertChip(String text) {
+        JLabel lbl = new JLabel(text.toUpperCase());
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        lbl.setForeground(new Color(37, 99, 235));
+        lbl.setBackground(Color.WHITE);
+        lbl.setOpaque(true);
+        lbl.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        lbl.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(190, 210, 255)),
+                new EmptyBorder(6, 12, 6, 12)));
+        return lbl;
+    }
+
+    private JLabel alertMessage(String text) {
+        JLabel lbl = new JLabel(text);
+        lbl.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        lbl.setForeground(new Color(233, 240, 255));
+        return lbl;
+    }
+
+    private JPanel metricsRow() {
+        JPanel row = new JPanel(new GridLayout(1, 4, 16, 0));
+        row.setOpaque(false);
+        row.add(metricCard("Tareas pendientes", "7", "Nuevas tareas", new Color(58, 109, 255)));
+        row.add(metricCard("Aprob. pendientes", "3", "Documentos en revisión", new Color(86, 127, 255)));
+        row.add(metricCard("Insumos críticos", "12", "Requieren pedido urgente", new Color(255, 99, 99)));
+        row.add(metricCard("Balance dpto", "$145.200", "Órdenes de compra", new Color(58, 182, 186)));
+        return row;
+    }
+
+    private JPanel metricCard(String title, String value, String hint, Color base) {
+        JPanel card = new JPanel() {
+            @Override
+            protected void paintComponent(Graphics g) {
+                Graphics2D g2 = (Graphics2D) g.create();
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setPaint(new GradientPaint(0, 0, base, getWidth(), getHeight(), base.darker()));
+                g2.fillRoundRect(0, 0, getWidth(), getHeight(), 22, 22);
+                g2.dispose();
+                super.paintComponent(g);
+            }
+        };
+        card.setOpaque(false);
+        card.setLayout(new BorderLayout());
+        card.setBorder(new EmptyBorder(18, 20, 18, 20));
+        card.setPreferredSize(new Dimension(0, 100));
+
+        JLabel lblTitle = new JLabel(title.toUpperCase());
+        lblTitle.setForeground(new Color(217, 230, 255));
+        lblTitle.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        JLabel lblValue = new JLabel(value);
+        lblValue.setForeground(Color.WHITE);
+        lblValue.setFont(new Font("Segoe UI", Font.BOLD, 28));
+        JLabel lblHint = new JLabel(hint);
+        lblHint.setForeground(new Color(220, 231, 255));
+        lblHint.setFont(new Font("Segoe UI", Font.PLAIN, 12));
+
+        card.add(lblTitle, BorderLayout.NORTH);
+        card.add(lblValue, BorderLayout.CENTER);
+        card.add(lblHint, BorderLayout.SOUTH);
+        return card;
+    }
+
+    private JComponent buildDashboardGrid() {
+        JPanel grid = new JPanel(new GridBagLayout());
+        grid.setOpaque(false);
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.insets = new Insets(0, 12, 18, 12);
+        gc.fill = GridBagConstraints.BOTH;
+        gc.weightx = 0.5;
+        gc.weighty = 0.5;
+
+        gc.gridx = 0;
+        gc.gridy = 0;
+        grid.add(upcomingEventsCard(), gc);
+
+        gc.gridx = 1;
+        grid.add(activityCard(), gc);
+
+        gc.gridx = 0;
+        gc.gridy = 1;
+        grid.add(priorityCard(), gc);
+
+        gc.gridx = 1;
+        grid.add(recentAccessCard(), gc);
+
+        return grid;
+    }
+
+    private CardPanel upcomingEventsCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sectionTitle("Próximos eventos"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        list.add(eventRow("10:00 Reunión Dpto.", "Decanato de Ciencias"));
+        list.add(divider());
+        list.add(eventRow("12:30 Comité Compras", "Sala 3 - Mesa de Compras"));
+        list.add(divider());
+        list.add(eventRow("14:00 Seguimiento Proyectos", "Sala Multimedia"));
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel activityCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sectionTitle("Actividad reciente"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        for (String[] row : new String[][]{
+                {"Hace 5 min", "Juan P. aprobó Traspaso de Inventario"},
+                {"Hace 15 min", "M. López registró movimiento de tóner"},
+                {"Hace 30 min", "Admin derivó Expediente 123/24 a Compras"},
+                {"Hace 1 h", "S. Ruiz finalizó Pedido de Suministros"}
+        }) {
+            list.add(activityRow(row[0], row[1]));
+            list.add(divider());
+        }
+        list.add(activityRow("Hace 2 h", "Tesorería generó Orden de Compra 89"));
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel priorityCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sectionTitle("Tareas prioritarias"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        list.add(priorityRow("Revisar solicitud de préstamo de proyector", true));
+        list.add(priorityRow("Aprobar orden #2034-09", false));
+        list.add(priorityRow("Actualizar inventario laboratorio B", false));
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel recentAccessCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sectionTitle("Accesos recientes"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        for (String[] row : new String[][]{
+                {"Hace 5 min", "Juan P. - Aprobó presupuesto de inventario"},
+                {"Hace 9 min", "María L. - Revisó Compras"},
+                {"Hace 15 min", "Sofía R. - Actualizó tramites"},
+                {"Hace 20 min", "Admin - Registró nueva orden"}
+        }) {
+            list.add(activityRow(row[0], row[1]));
+            list.add(divider());
+        }
+        list.add(activityRow("Hace 30 min", "Carlos D. - Revisó finanzas"));
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private JLabel sectionTitle(String text) {
+        JLabel lbl = new JLabel(text);
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 16));
+        lbl.setForeground(new Color(35, 55, 110));
+        return lbl;
+    }
+
+    private Component eventRow(String title, String subtitle) {
+        JPanel row = new JPanel(new BorderLayout());
+        row.setOpaque(false);
+        JLabel lblTitle = new JLabel(title);
+        lblTitle.setFont(new Font("Segoe UI", Font.BOLD, 14));
+        lblTitle.setForeground(new Color(40, 56, 120));
+        JLabel lblSubtitle = new JLabel(subtitle);
+        lblSubtitle.setFont(new Font("Segoe UI", Font.PLAIN, 12));
+        lblSubtitle.setForeground(new Color(120, 136, 180));
+        row.add(lblTitle, BorderLayout.NORTH);
+        row.add(lblSubtitle, BorderLayout.SOUTH);
+        return row;
+    }
+
+    private Component activityRow(String when, String description) {
+        JPanel row = new JPanel(new BorderLayout());
+        row.setOpaque(false);
+        JLabel lblWhen = new JLabel(when);
+        lblWhen.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        lblWhen.setForeground(new Color(92, 109, 161));
+        JLabel lblDesc = new JLabel(description);
+        lblDesc.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        lblDesc.setForeground(new Color(45, 63, 120));
+        row.add(lblWhen, BorderLayout.NORTH);
+        row.add(lblDesc, BorderLayout.CENTER);
+        return row;
+    }
+
+    private Component priorityRow(String text, boolean completed) {
+        JCheckBox check = new JCheckBox(text);
+        check.setOpaque(false);
+        check.setSelected(completed);
+        check.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        check.setForeground(new Color(45, 63, 120));
+        return check;
+    }
+
+    private JSeparator divider() {
+        JSeparator sep = new JSeparator();
+        sep.setForeground(new Color(230, 236, 250));
+        sep.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
+        return sep;
+    }
+
+    private CardPanel buildQuickActions() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 18));
+        card.add(sectionTitle("Accesos rápidos"), BorderLayout.NORTH);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 16, 0));
+        buttons.setOpaque(false);
+        buttons.add(primaryButton("Registrar nuevo trámite"));
+        buttons.add(secondaryButton("Generar orden de compra"));
+        buttons.add(secondaryButton("Ver reportes"));
+        card.add(buttons, BorderLayout.CENTER);
+
+        JLabel footer = new JLabel("" + LocalDate.now().format(friendlyDate));
+        footer.setForeground(new Color(125, 139, 170));
+        footer.setFont(new Font("Segoe UI", Font.PLAIN, 12));
+        card.add(footer, BorderLayout.SOUTH);
+        return card;
+    }
+
+    private JButton primaryButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setFont(new Font("Segoe UI", Font.BOLD, 14));
+        b.setForeground(Color.WHITE);
+        b.setBackground(new Color(52, 99, 240));
+        b.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
+    }
+
+    private JButton secondaryButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setFont(new Font("Segoe UI", Font.PLAIN, 14));
+        b.setForeground(new Color(52, 99, 240));
+        b.setBackground(new Color(231, 238, 255));
+        b.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
+    }
+
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -1,19 +1,26 @@
 package ar.edu.unse.siga.ui.pages;
 
-import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.domain.Tramite;
+import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.ui.base.CardPanel;
 import ar.edu.unse.siga.ui.base.Ui;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.JTableHeader;
 import java.awt.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 public class TramiteEntradaPage extends JPanel {
+
     private final TramiteService service;
 
     private final JTextField txtAsunto = new JTextField(25);
@@ -23,171 +30,18 @@ public class TramiteEntradaPage extends JPanel {
     private final JTextField txtDestinatario = new JTextField(25);
     private final JLabel lblNumero = new JLabel();
 
+    private final JTextField filterSearch = new JTextField(18);
+    private final JComboBox<String> filterCategoria = new JComboBox<>(
+            new String[]{"Todas", "Matrículas", "Ingresos", "Suministros", "Pagos"});
+    private final JComboBox<String> filterEstado = new JComboBox<>(
+            new String[]{"Todos", "Completado", "En proceso", "Pendiente", "Alta"});
+
     private final CardLayout cardLayout = new CardLayout();
     private final JPanel cards = new JPanel(cardLayout);
 
-    public TramiteEntradaPage(TramiteService service) {
-        this.service = service;
-        setOpaque(false);
-        setLayout(new BorderLayout(20, 20));
-
-        add(buildHeader(), BorderLayout.NORTH);
-        add(buildContent(), BorderLayout.CENTER);
-
-        lblNumero.setText(generateNumero(LocalDate.now()));
-        cardLayout.show(cards, "registro");
-    }
-
-    private JComponent buildHeader() {
-        JPanel header = new JPanel(new BorderLayout(12, 12));
-        header.setOpaque(false);
-
-        JLabel title = new JLabel("Trámites");
-        title.setFont(title.getFont().deriveFont(Font.BOLD, 30f));
-        title.setForeground(new Color(24, 63, 150));
-        header.add(title, BorderLayout.WEST);
-
-        return header;
-    }
-
-    private JComponent buildContent() {
-        JPanel wrapper = new JPanel(new BorderLayout(12, 18));
-        wrapper.setOpaque(false);
-
-        ButtonGroup tabs = new ButtonGroup();
-        JToggleButton btnRegistrar = pill("Registrar nuevo trámite");
-        JToggleButton btnActivos = pill("Trámites activos");
-        btnRegistrar.setSelected(true);
-        tabs.add(btnRegistrar);
-        tabs.add(btnActivos);
-
-        JPanel tabRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
-        tabRow.setOpaque(false);
-        tabRow.add(btnRegistrar);
-        tabRow.add(btnActivos);
-        wrapper.add(tabRow, BorderLayout.NORTH);
-
-        cards.setOpaque(false);
-        cards.add(buildRegistroCard(), "registro");
-        cards.add(buildActivosCard(), "activos");
-
-        btnRegistrar.addActionListener(e -> cardLayout.show(cards, "registro"));
-        btnActivos.addActionListener(e -> {
-            loadTableData();
-            cardLayout.show(cards, "activos");
-        });
-
-        wrapper.add(cards, BorderLayout.CENTER);
-        return wrapper;
-    }
-
-    private CardPanel buildRegistroCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(18, 18));
-
-        JPanel columns = new JPanel(new GridLayout(1, 2, 18, 0));
-        columns.setOpaque(false);
-
-        columns.add(buildFormPanel());
-        columns.add(buildSidebarPanel());
-        card.add(columns, BorderLayout.CENTER);
-        return card;
-    }
-
-    private CardPanel buildFormPanel() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 12));
-
-        JLabel title = new JLabel("Detalle del trámite".toUpperCase());
-        title.setForeground(new Color(73, 103, 204));
-        title.setFont(title.getFont().deriveFont(Font.BOLD, 14f));
-        card.add(title, BorderLayout.NORTH);
-
-        JPanel form = new JPanel();
-        form.setOpaque(false);
-        form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
-
-        form.add(infoLabel("Número generado", lblNumero));
-        form.add(Box.createVerticalStrut(12));
-        form.add(field("Asunto", txtAsunto));
-        form.add(Box.createVerticalStrut(12));
-        form.add(field("Remitente", txtRemitente));
-        form.add(Box.createVerticalStrut(12));
-        txtDescripcion.setLineWrap(true);
-        txtDescripcion.setWrapStyleWord(true);
-        form.add(textAreaField("Descripción", txtDescripcion));
-        form.add(Box.createVerticalStrut(12));
-        form.add(field("Destino", txtDestino));
-        form.add(Box.createVerticalStrut(12));
-        form.add(field("Destinatario", txtDestinatario));
-
-        JButton btn = primaryButton("Aceptar");
-        btn.addActionListener(e -> onSave());
-        btn.setAlignmentX(Component.CENTER_ALIGNMENT);
-        form.add(Box.createVerticalStrut(18));
-        form.add(btn);
-
-        card.add(form, BorderLayout.CENTER);
-        return card;
-    }
-
-    private CardPanel buildSidebarPanel() {
-        CardPanel container = new CardPanel();
-        container.setLayout(new GridLayout(2, 1, 12, 12));
-        container.add(listCard("Trámites recientes", new String[][]{
-                {"Asunto: Presupuesto 2026", "Estado: EN PROCESO"},
-                {"Asunto: Pedido resma A4", "Estado: COMPLETADO"},
-                {"Asunto: Solicitud equipamiento", "Estado: PENDIENTE"}
-        }));
-        container.add(listCard("Trámites más antiguos", new String[][]{
-                {"Asunto: Compra equipos Lab.", "Fecha: 23/09/2024"},
-                {"Asunto: Presupuesto Decanato", "Fecha: 12/01/2025"}
-        }));
-        return container;
-    }
-
-    private CardPanel buildActivosCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 12));
-
-        JLabel title = new JLabel("Trámites activos".toUpperCase());
-        title.setForeground(new Color(73, 103, 204));
-        title.setFont(title.getFont().deriveFont(Font.BOLD, 14f));
-        card.add(title, BorderLayout.NORTH);
-
-        card.add(new JScrollPane(table), BorderLayout.CENTER);
-        return card;
-    }
-
-    private String generateNumero(LocalDate d) {
-        // Ej: 20240915-00123 (simplificado)
-        return d.format(DateTimeFormatter.BASIC_ISO_DATE) + "-" + (int)(Math.random()*90000+10000);
-    }
-
-    private void onSave() {
-        try {
-            String nro = lblNumero.getText();
-            String asunto = txtAsunto.getText().trim();
-            String solicitante = txtRemitente.getText().trim();
-            if (asunto.isEmpty()) throw new IllegalArgumentException("El asunto es obligatorio");
-
-            service.registrarTramite(nro, asunto, solicitante);
-
-            Ui.info(this, "Trámite registrado.");
-            lblNumero.setText(generateNumero(LocalDate.now()));
-            txtAsunto.setText("");
-            txtRemitente.setText("");
-            txtDescripcion.setText("");
-            txtDestino.setText("");
-            txtDestinatario.setText("");
-        } catch(Exception e) {
-            Ui.error(this, e);
-        }
-    }
-
     private final JTable table = new JTable(new DefaultTableModel(
             new Object[][]{},
-            new Object[]{"Número", "Asunto", "Estado", "Fecha"}
+            new String[]{"ID Trámite", "Asunto", "Fecha actualización", "Última actualización", "Prioridad", "Estado"}
     )) {
         @Override
         public boolean isCellEditable(int row, int column) {
@@ -195,32 +49,382 @@ public class TramiteEntradaPage extends JPanel {
         }
     };
 
+    public TramiteEntradaPage(TramiteService service) {
+        this.service = service;
+        setOpaque(false);
+        setLayout(new BorderLayout(0, 20));
+
+        add(buildHeader(), BorderLayout.NORTH);
+        add(buildContent(), BorderLayout.CENTER);
+
+        lblNumero.setText(generateNumero(LocalDate.now()));
+        cardLayout.show(cards, "registro");
+        configureTable();
+        installFilters();
+    }
+
+    private JComponent buildHeader() {
+        JPanel header = new JPanel(new BorderLayout());
+        header.setOpaque(false);
+
+        JLabel title = new JLabel("Trámites");
+        title.setFont(new Font("Segoe UI", Font.BOLD, 32));
+        title.setForeground(new Color(35, 55, 120));
+        header.add(title, BorderLayout.WEST);
+
+        ButtonGroup tabs = new ButtonGroup();
+        JToggleButton btnRegistrar = tabButton("Registrar nuevo trámite");
+        JToggleButton btnActivos = tabButton("Trámites activos");
+        tabs.add(btnRegistrar);
+        tabs.add(btnActivos);
+        btnRegistrar.setSelected(true);
+
+        JPanel switches = new JPanel(new FlowLayout(FlowLayout.RIGHT, 12, 0));
+        switches.setOpaque(false);
+        switches.add(btnRegistrar);
+        switches.add(btnActivos);
+        header.add(switches, BorderLayout.EAST);
+
+        btnRegistrar.addActionListener(e -> cardLayout.show(cards, "registro"));
+        btnActivos.addActionListener(e -> {
+            loadTableData();
+            cardLayout.show(cards, "activos");
+        });
+
+        return header;
+    }
+
+    private JComponent buildContent() {
+        cards.setOpaque(false);
+        cards.add(buildRegistroCard(), "registro");
+        cards.add(buildActivosCard(), "activos");
+        return cards;
+    }
+
+    private CardPanel buildRegistroCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(24, 24));
+
+        JPanel columns = new JPanel(new GridBagLayout());
+        columns.setOpaque(false);
+
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridx = 0;
+        gc.gridy = 0;
+        gc.weightx = 0.6;
+        gc.fill = GridBagConstraints.BOTH;
+        gc.insets = new Insets(0, 0, 0, 18);
+        columns.add(buildFormPanel(), gc);
+
+        gc.gridx = 1;
+        gc.weightx = 0.4;
+        gc.insets = new Insets(0, 18, 0, 0);
+        columns.add(buildSidebarPanel(), gc);
+
+        card.add(columns, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel buildFormPanel() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(18, 18));
+
+        JLabel title = new JLabel("Detalle del trámite");
+        title.setFont(new Font("Segoe UI", Font.BOLD, 16));
+        title.setForeground(new Color(54, 92, 190));
+        card.add(title, BorderLayout.NORTH);
+
+        JPanel form = new JPanel();
+        form.setOpaque(false);
+        form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
+
+        form.add(infoLabel("Número generado", lblNumero));
+        form.add(Box.createVerticalStrut(16));
+        form.add(field("Asunto", txtAsunto));
+        form.add(Box.createVerticalStrut(14));
+        form.add(field("Remitente", txtRemitente));
+        form.add(Box.createVerticalStrut(14));
+        txtDescripcion.setLineWrap(true);
+        txtDescripcion.setWrapStyleWord(true);
+        form.add(textAreaField("Descripción", txtDescripcion));
+        form.add(Box.createVerticalStrut(14));
+        form.add(field("Destino", txtDestino));
+        form.add(Box.createVerticalStrut(14));
+        form.add(field("Destinatario", txtDestinatario));
+
+        JButton btn = primaryButton("Aceptar");
+        btn.addActionListener(e -> onSave());
+        btn.setAlignmentX(Component.LEFT_ALIGNMENT);
+        form.add(Box.createVerticalStrut(22));
+        form.add(btn);
+
+        card.add(form, BorderLayout.CENTER);
+        return card;
+    }
+
+    private JComponent buildSidebarPanel() {
+        JPanel grid = new JPanel(new GridLayout(2, 1, 18, 18));
+        grid.setOpaque(false);
+        grid.add(recentTramitesCard());
+        grid.add(oldTramitesCard());
+        return grid;
+    }
+
+    private CardPanel recentTramitesCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sideTitle("Trámites recientes"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        list.add(recentItem("Asunto: Presupuesto 2026", "Estado: COMPLETADO", "Completo", new Color(73, 198, 154)));
+        list.add(recentItem("Asunto: Pedido resma A4", "Estado: EN PROCESO", "En proceso", new Color(86, 127, 255)));
+        list.add(recentItem("Asunto: Solicitud equipamiento", "Estado: PENDIENTE", "Pendiente", new Color(255, 170, 70)));
+
+        JButton link = subtleLink("Ver historial completo");
+        list.add(Box.createVerticalStrut(12));
+        list.add(link);
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel oldTramitesCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(0, 12));
+        card.add(sideTitle("Trámites más antiguos"), BorderLayout.NORTH);
+
+        JPanel list = new JPanel();
+        list.setOpaque(false);
+        list.setLayout(new BoxLayout(list, BoxLayout.Y_AXIS));
+        list.add(twoLineItem("Asunto: Compra equipos Lab.", "Fecha: 23/09/2024"));
+        list.add(twoLineItem("Asunto: Presupuesto Decanato", "Fecha: 12/01/2025"));
+        list.add(twoLineItem("Asunto: Renovación licencias", "Fecha: 08/02/2025"));
+
+        JButton link = subtleLink("Ver historial completo");
+        list.add(Box.createVerticalStrut(12));
+        list.add(link);
+
+        card.add(list, BorderLayout.CENTER);
+        return card;
+    }
+
+    private CardPanel buildActivosCard() {
+        CardPanel card = new CardPanel();
+        card.setLayout(new BorderLayout(20, 24));
+
+        card.add(buildFilters(), BorderLayout.NORTH);
+        card.add(buildTableScroll(), BorderLayout.CENTER);
+
+        return card;
+    }
+
+    private Component buildFilters() {
+        JPanel panel = new JPanel(new BorderLayout(18, 0));
+        panel.setOpaque(false);
+
+        JLabel lbl = new JLabel("Filtro");
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 16));
+        lbl.setForeground(new Color(45, 66, 132));
+        panel.add(lbl, BorderLayout.WEST);
+
+        JPanel fields = new JPanel(new FlowLayout(FlowLayout.LEFT, 12, 0));
+        fields.setOpaque(false);
+        styleFilterField(filterSearch, 220);
+        filterSearch.putClientProperty("JTextField.placeholderText", "Buscar");
+        fields.add(filterSearch);
+
+        styleFilterField(filterCategoria, 160);
+        fields.add(filterCategoria);
+
+        styleFilterField(filterEstado, 160);
+        fields.add(filterEstado);
+
+        panel.add(fields, BorderLayout.CENTER);
+
+        JButton export = outlineButton("Exportar PDF");
+        export.addActionListener(e -> Ui.info(this, "Funcionalidad de exportación en desarrollo."));
+        panel.add(export, BorderLayout.EAST);
+
+        return panel;
+    }
+
+    private JScrollPane buildTableScroll() {
+        table.setRowHeight(44);
+        table.setShowHorizontalLines(false);
+        table.setShowVerticalLines(false);
+        table.setIntercellSpacing(new Dimension(0, 0));
+        table.setFillsViewportHeight(true);
+        table.setSelectionBackground(new Color(226, 233, 255));
+        table.setSelectionForeground(new Color(32, 48, 105));
+        table.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        table.setAutoCreateRowSorter(true);
+
+        JTableHeader header = table.getTableHeader();
+        header.setPreferredSize(new Dimension(header.getPreferredSize().width, 46));
+        header.setDefaultRenderer(new TableHeaderRenderer());
+
+        table.getColumnModel().getColumn(4).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.PRIORITY));
+        table.getColumnModel().getColumn(5).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.STATUS));
+
+        JScrollPane scroll = new JScrollPane(table);
+        scroll.setBorder(BorderFactory.createEmptyBorder());
+        scroll.getViewport().setBackground(Color.WHITE);
+        return scroll;
+    }
+
+    private void configureTable() {
+        loadTableData();
+    }
+
+    private void installFilters() {
+        filterSearch.getDocument().addDocumentListener(new SimpleDocumentListener(this::loadTableData));
+        filterCategoria.addActionListener(e -> loadTableData());
+        filterEstado.addActionListener(e -> loadTableData());
+    }
+
+    private String generateNumero(LocalDate date) {
+        return date.format(DateTimeFormatter.BASIC_ISO_DATE) + "-" + (int) (Math.random() * 90000 + 10000);
+    }
+
+    private void onSave() {
+        try {
+            String nro = lblNumero.getText();
+            String asunto = txtAsunto.getText().trim();
+            String solicitante = txtRemitente.getText().trim();
+            if (asunto.isEmpty()) {
+                throw new IllegalArgumentException("El asunto es obligatorio");
+            }
+
+            service.registrarTramite(nro, asunto, solicitante);
+
+            Ui.info(this, "Trámite registrado correctamente.");
+            lblNumero.setText(generateNumero(LocalDate.now()));
+            txtAsunto.setText("");
+            txtRemitente.setText("");
+            txtDescripcion.setText("");
+            txtDestino.setText("");
+            txtDestinatario.setText("");
+            loadTableData();
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
     private void loadTableData() {
         DefaultTableModel model = (DefaultTableModel) table.getModel();
         model.setRowCount(0);
         try {
+            String search = filterSearch.getText().trim().toLowerCase(Locale.ROOT);
+            String categoria = (String) filterCategoria.getSelectedItem();
+            String estadoFiltro = (String) filterEstado.getSelectedItem();
+
             List<Tramite> tramites = service.listarTodos();
             for (Tramite t : tramites) {
+                if (!search.isEmpty()) {
+                    String texto = (t.getAsunto() + " " + t.getNro()).toLowerCase(Locale.ROOT);
+                    if (!texto.contains(search)) {
+                        continue;
+                    }
+                }
+                if (!"Todas".equalsIgnoreCase(categoria) && !matchesCategoria(t, categoria)) {
+                    continue;
+                }
+                if (!"Todos".equalsIgnoreCase(estadoFiltro) && !estadoMatches(t.getEstado(), estadoFiltro)) {
+                    continue;
+                }
+
                 LocalDateTime fecha = t.getFecha();
-                String f = fecha != null ? fecha.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")) : "-";
-                model.addRow(new Object[]{t.getNro(), t.getAsunto(), t.getEstado(), f});
+                String actualizacion = fecha != null
+                        ? fecha.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+                        : "-";
+                String ultima = fecha != null
+                        ? fecha.minusDays(1).format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+                        : "-";
+
+                String prioridad = prioridadDesdeEstado(t.getEstado());
+                String estado = estadoFriendly(t.getEstado());
+
+                model.addRow(new Object[]{
+                        t.getNro(),
+                        t.getAsunto(),
+                        actualizacion,
+                        ultima,
+                        prioridad,
+                        estado
+                });
             }
         } catch (Exception ex) {
             Ui.error(this, ex);
         }
     }
 
+    private boolean matchesCategoria(Tramite t, String categoria) {
+        if (t.getAsunto() == null) {
+            return false;
+        }
+        String asunto = t.getAsunto().toLowerCase(Locale.ROOT);
+        return switch (categoria) {
+            case "Matrículas" -> asunto.contains("matric");
+            case "Ingresos" -> asunto.contains("ingres");
+            case "Suministros" -> asunto.contains("suminis") || asunto.contains("pedido");
+            case "Pagos" -> asunto.contains("pago") || asunto.contains("orden");
+            default -> true;
+        };
+    }
+
+    private boolean estadoMatches(String estado, String filtro) {
+        if (estado == null) {
+            return false;
+        }
+        String normalized = estadoFriendly(estado).toLowerCase(Locale.ROOT);
+        return normalized.equals(filtro.toLowerCase(Locale.ROOT));
+    }
+
+    private String prioridadDesdeEstado(String estado) {
+        if (estado == null) {
+            return "Media";
+        }
+        return switch (estado.toUpperCase(Locale.ROOT)) {
+            case "CERRADO", "COMPLETADO" -> "Baja";
+            case "EN_PROCESO" -> "Media";
+            case "ALTA" -> "Alta";
+            default -> "Alta";
+        };
+    }
+
+    private String estadoFriendly(String estado) {
+        if (estado == null) {
+            return "Pendiente";
+        }
+        return switch (estado.toUpperCase(Locale.ROOT)) {
+            case "COMPLETADO", "CERRADO" -> "Completado";
+            case "EN_PROCESO" -> "En proceso";
+            case "ALTA" -> "Alta";
+            default -> capitalize(estado);
+        };
+    }
+
+    private String capitalize(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return text.substring(0, 1).toUpperCase(Locale.ROOT) + text.substring(1).toLowerCase(Locale.ROOT);
+    }
+
     private JPanel field(String label, JComponent component) {
         JPanel p = new JPanel();
         p.setOpaque(false);
         p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
-        JLabel lbl = new JLabel(label.toUpperCase());
+        JLabel lbl = new JLabel(label.toUpperCase(Locale.ROOT));
         lbl.setAlignmentX(Component.LEFT_ALIGNMENT);
-        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        lbl.setForeground(new Color(87, 110, 178));
         component.setAlignmentX(Component.LEFT_ALIGNMENT);
-        component.putClientProperty("JComponent.roundRect", true);
+        styleInput(component);
         p.add(lbl);
-        p.add(Box.createVerticalStrut(4));
+        p.add(Box.createVerticalStrut(6));
         p.add(component);
         return p;
     }
@@ -229,54 +433,124 @@ public class TramiteEntradaPage extends JPanel {
         JPanel p = new JPanel();
         p.setOpaque(false);
         p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
-        JLabel lbl = new JLabel(label.toUpperCase());
+        JLabel lbl = new JLabel(label.toUpperCase(Locale.ROOT));
         lbl.setAlignmentX(Component.LEFT_ALIGNMENT);
-        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        lbl.setForeground(new Color(87, 110, 178));
         area.setAlignmentX(Component.LEFT_ALIGNMENT);
-        area.setBorder(BorderFactory.createLineBorder(new Color(205, 218, 255)));
+        area.setBorder(new EmptyBorder(8, 12, 8, 12));
+        area.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        JScrollPane scroll = new JScrollPane(area);
+        scroll.setBorder(BorderFactory.createLineBorder(new Color(211, 220, 249)));
+        scroll.setAlignmentX(Component.LEFT_ALIGNMENT);
         p.add(lbl);
-        p.add(Box.createVerticalStrut(4));
-        p.add(new JScrollPane(area));
+        p.add(Box.createVerticalStrut(6));
+        p.add(scroll);
         return p;
     }
 
     private JPanel infoLabel(String title, JLabel value) {
         JPanel panel = new JPanel(new BorderLayout());
         panel.setOpaque(false);
-        JLabel lblTitle = new JLabel(title.toUpperCase());
-        lblTitle.setFont(lblTitle.getFont().deriveFont(Font.PLAIN, 12f));
+        JLabel lblTitle = new JLabel(title.toUpperCase(Locale.ROOT));
+        lblTitle.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        lblTitle.setForeground(new Color(87, 110, 178));
         panel.add(lblTitle, BorderLayout.NORTH);
-        value.setFont(value.getFont().deriveFont(Font.BOLD, 16f));
+        value.setFont(new Font("Segoe UI", Font.BOLD, 20));
+        value.setForeground(new Color(35, 63, 150));
         panel.add(value, BorderLayout.CENTER);
         return panel;
     }
 
-    private CardPanel listCard(String title, String[][] rows) {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(6, 6));
-        JLabel lblTitle = new JLabel(title.toUpperCase());
-        lblTitle.setForeground(new Color(73, 103, 204));
-        lblTitle.setFont(lblTitle.getFont().deriveFont(Font.BOLD, 13f));
-        card.add(lblTitle, BorderLayout.NORTH);
+    private JLabel sideTitle(String text) {
+        JLabel lbl = new JLabel(text);
+        lbl.setFont(new Font("Segoe UI", Font.BOLD, 14));
+        lbl.setForeground(new Color(54, 92, 190));
+        return lbl;
+    }
 
-        JPanel content = new JPanel();
-        content.setOpaque(false);
-        content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
-        for (String[] row : rows) {
-            JLabel line = new JLabel("<html>" + row[0] + "<br>" + row[1] + "</html>");
-            line.setBorder(BorderFactory.createEmptyBorder(4, 0, 4, 0));
-            content.add(line);
+    private Component recentItem(String title, String subtitle, String badge, Color badgeColor) {
+        JPanel row = new JPanel(new BorderLayout());
+        row.setOpaque(false);
+        JLabel lblTitle = new JLabel(title);
+        lblTitle.setFont(new Font("Segoe UI", Font.BOLD, 13));
+        lblTitle.setForeground(new Color(43, 57, 120));
+        JLabel lblSubtitle = new JLabel(subtitle);
+        lblSubtitle.setFont(new Font("Segoe UI", Font.PLAIN, 12));
+        lblSubtitle.setForeground(new Color(118, 133, 182));
+
+        JPanel left = new JPanel();
+        left.setOpaque(false);
+        left.setLayout(new BoxLayout(left, BoxLayout.Y_AXIS));
+        left.add(lblTitle);
+        left.add(Box.createVerticalStrut(4));
+        left.add(lblSubtitle);
+
+        JLabel badgeLabel = new JLabel(badge);
+        badgeLabel.setOpaque(true);
+        badgeLabel.setBackground(badgeColor);
+        badgeLabel.setForeground(Color.WHITE);
+        badgeLabel.setFont(new Font("Segoe UI", Font.BOLD, 11));
+        badgeLabel.setBorder(new EmptyBorder(4, 12, 4, 12));
+        badgeLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        badgeLabel.setAlignmentY(Component.TOP_ALIGNMENT);
+
+        row.add(left, BorderLayout.CENTER);
+        row.add(badgeLabel, BorderLayout.EAST);
+        row.setBorder(new EmptyBorder(4, 0, 4, 0));
+        return row;
+    }
+
+    private Component twoLineItem(String title, String subtitle) {
+        JPanel row = new JPanel();
+        row.setOpaque(false);
+        row.setLayout(new BoxLayout(row, BoxLayout.Y_AXIS));
+        JLabel lblTitle = new JLabel(title);
+        lblTitle.setFont(new Font("Segoe UI", Font.BOLD, 13));
+        lblTitle.setForeground(new Color(43, 57, 120));
+        JLabel lblSubtitle = new JLabel(subtitle);
+        lblSubtitle.setFont(new Font("Segoe UI", Font.PLAIN, 12));
+        lblSubtitle.setForeground(new Color(118, 133, 182));
+        row.add(lblTitle);
+        row.add(Box.createVerticalStrut(4));
+        row.add(lblSubtitle);
+        row.setBorder(new EmptyBorder(4, 0, 4, 0));
+        return row;
+    }
+
+    private JButton subtleLink(String text) {
+        JButton b = new JButton(text);
+        b.setContentAreaFilled(false);
+        b.setBorderPainted(false);
+        b.setFocusPainted(false);
+        b.setHorizontalAlignment(SwingConstants.LEFT);
+        b.setForeground(new Color(68, 105, 220));
+        b.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        return b;
+    }
+
+    private void styleInput(JComponent component) {
+        component.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(211, 220, 249)),
+                new EmptyBorder(10, 14, 10, 14)));
+        component.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        component.setBackground(Color.WHITE);
+        component.setMaximumSize(new Dimension(Integer.MAX_VALUE, 44));
+    }
+
+    private void styleFilterField(JComponent component, int width) {
+        component.putClientProperty("JComponent.sizeVariant", "regular");
+        component.setPreferredSize(new Dimension(width, 40));
+        component.setFont(new Font("Segoe UI", Font.PLAIN, 13));
+        if (component instanceof JTextField textField) {
+            textField.setBorder(BorderFactory.createCompoundBorder(
+                    BorderFactory.createLineBorder(new Color(208, 218, 245)),
+                    new EmptyBorder(8, 12, 8, 12)));
+            textField.setBackground(Color.WHITE);
+        } else if (component instanceof JComboBox<?>) {
+            component.setBorder(BorderFactory.createLineBorder(new Color(208, 218, 245)));
+            component.setBackground(Color.WHITE);
         }
-        JButton link = new JButton("Ver historial completo");
-        link.setContentAreaFilled(false);
-        link.setBorderPainted(false);
-        link.setForeground(new Color(58, 96, 224));
-        link.setAlignmentX(Component.LEFT_ALIGNMENT);
-        content.add(Box.createVerticalStrut(8));
-        content.add(link);
-
-        card.add(content, BorderLayout.CENTER);
-        return card;
     }
 
     private JButton primaryButton(String text) {
@@ -284,28 +558,134 @@ public class TramiteEntradaPage extends JPanel {
         b.setBackground(new Color(58, 96, 224));
         b.setForeground(Color.WHITE);
         b.setFocusPainted(false);
+        b.setBorder(BorderFactory.createEmptyBorder(12, 26, 12, 26));
         b.putClientProperty("JButton.buttonType", "roundRect");
         return b;
     }
 
-    private JToggleButton pill(String text) {
-        JToggleButton t = new JToggleButton(text.toUpperCase());
+    private JButton outlineButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setFont(new Font("Segoe UI", Font.BOLD, 13));
+        b.setForeground(new Color(58, 96, 224));
+        b.setBackground(Color.WHITE);
+        b.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(180, 200, 255)),
+                new EmptyBorder(10, 18, 10, 18)));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
+    }
+
+    private JToggleButton tabButton(String text) {
+        JToggleButton t = new JToggleButton(text.toUpperCase(Locale.ROOT));
         t.setFocusPainted(false);
-        t.setBackground(Color.WHITE);
-        t.setForeground(new Color(66, 100, 189));
-        t.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createLineBorder(new Color(205, 218, 255)),
-                BorderFactory.createEmptyBorder(8, 18, 8, 18)
-        ));
+        t.setFont(new Font("Segoe UI", Font.BOLD, 12));
+        t.setBackground(new Color(235, 240, 255));
+        t.setForeground(new Color(66, 98, 190));
+        t.setBorder(BorderFactory.createEmptyBorder(12, 24, 12, 24));
+        t.putClientProperty("JButton.buttonType", "roundRect");
         t.addChangeListener(e -> {
             if (t.isSelected()) {
                 t.setBackground(new Color(58, 96, 224));
                 t.setForeground(Color.WHITE);
             } else {
-                t.setBackground(Color.WHITE);
-                t.setForeground(new Color(66, 100, 189));
+                t.setBackground(new Color(235, 240, 255));
+                t.setForeground(new Color(66, 98, 190));
             }
         });
         return t;
+    }
+
+    private static class SimpleDocumentListener implements DocumentListener {
+        private final Runnable onChange;
+
+        private SimpleDocumentListener(Runnable onChange) {
+            this.onChange = onChange;
+        }
+
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            onChange.run();
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+            onChange.run();
+        }
+    }
+
+    private static class TableHeaderRenderer extends DefaultTableCellRenderer {
+        TableHeaderRenderer() {
+            setHorizontalAlignment(LEFT);
+            setFont(new Font("Segoe UI", Font.BOLD, 13));
+            setForeground(new Color(70, 88, 140));
+            setBackground(new Color(238, 242, 255));
+            setBorder(new EmptyBorder(12, 14, 12, 14));
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                                                       boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setText(value == null ? "" : value.toString().toUpperCase(Locale.ROOT));
+            return this;
+        }
+    }
+
+    private static class BadgeRenderer extends DefaultTableCellRenderer {
+        enum Type { PRIORITY, STATUS }
+        private final Type type;
+
+        BadgeRenderer(Type type) {
+            this.type = type;
+            setHorizontalAlignment(CENTER);
+            setFont(new Font("Segoe UI", Font.BOLD, 12));
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                                                       boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            String text = value == null ? "-" : value.toString();
+            setText(text);
+            setOpaque(true);
+            setBorder(new EmptyBorder(6, 12, 6, 12));
+
+            Color base;
+            String normalized = text.toLowerCase(Locale.ROOT);
+            if (type == Type.PRIORITY) {
+                if (normalized.contains("alta")) {
+                    base = new Color(255, 120, 102);
+                } else if (normalized.contains("media")) {
+                    base = new Color(255, 188, 75);
+                } else {
+                    base = new Color(200, 210, 230);
+                }
+            } else {
+                if (normalized.contains("complet")) {
+                    base = new Color(73, 198, 154);
+                } else if (normalized.contains("proceso")) {
+                    base = new Color(86, 127, 255);
+                } else if (normalized.contains("alta")) {
+                    base = new Color(255, 120, 102);
+                } else {
+                    base = new Color(255, 188, 75);
+                }
+            }
+
+            if (isSelected) {
+                setForeground(Color.WHITE);
+                setBackground(base.darker());
+            } else {
+                setForeground(Color.WHITE);
+                setBackground(base);
+            }
+            return this;
+        }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/shell/NavButton.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/NavButton.java
@@ -9,42 +9,78 @@ import java.awt.*;
 
 public class NavButton extends JToggleButton implements ChangeListener {
 
-    private static final Color SELECTED_BG = Color.WHITE;
-    private static final Color SELECTED_FG = new Color(20, 67, 140);
-    private static final Color NORMAL_FG = new Color(245, 247, 255);
-    private static final Color HOVER_BG = new Color(255, 255, 255, 60);
+    private static final Color LEVEL0_SELECTED_BG = Color.WHITE;
+    private static final Color LEVEL0_SELECTED_FG = new Color(20, 67, 140);
+    private static final Color LEVEL0_NORMAL_FG = new Color(245, 247, 255);
+    private static final Color LEVEL0_HOVER_BG = new Color(255, 255, 255, 60);
+
+    private static final Color LEVEL1_SELECTED_BG = new Color(255, 255, 255, 230);
+    private static final Color LEVEL1_SELECTED_FG = new Color(29, 84, 173);
+    private static final Color LEVEL1_NORMAL_FG = new Color(224, 235, 255);
+    private static final Color LEVEL1_HOVER_BG = new Color(255, 255, 255, 80);
+
+    private final int level;
+    private final Color normalBg;
+    private final Color normalFg;
+    private final Color hoverBg;
+    private final Color selectedBg;
+    private final Color selectedFg;
 
     public NavButton(String text, String iconPath) {
+        this(text, iconPath, 0);
+    }
+
+    public NavButton(String text, String iconPath, int level) {
         super("  " + text);
+        this.level = Math.max(level, 0);
         if (iconPath != null && !iconPath.isBlank()) {
             setIcon((Icon) ThemeManager.svg(iconPath, 18));
         }
         setHorizontalAlignment(LEFT);
-        setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 16));
+        setBorder(BorderFactory.createEmptyBorder(this.level == 0 ? 10 : 8,
+                this.level == 0 ? 20 : 46,
+                this.level == 0 ? 10 : 8,
+                16));
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         setFocusPainted(false);
         setOpaque(true);
-        setBackground(new Color(255, 255, 255, 20));
-        setForeground(NORMAL_FG);
-        setFont(getFont().deriveFont(Font.BOLD, 14f));
+        setFont(getFont().deriveFont(this.level == 0 ? Font.BOLD : Font.PLAIN,
+                this.level == 0 ? 14f : 13f));
         setIconTextGap(12);
         putClientProperty("JButton.buttonType", "toolBarButton");
-        putClientProperty("JComponent.minimumWidth", 180);
-        putClientProperty("JComponent.minimumHeight", 46);
+        putClientProperty("JComponent.minimumWidth", this.level == 0 ? 180 : 168);
+        putClientProperty("JComponent.minimumHeight", this.level == 0 ? 46 : 40);
+
+        if (this.level == 0) {
+            normalBg = new Color(255, 255, 255, 20);
+            normalFg = LEVEL0_NORMAL_FG;
+            hoverBg = LEVEL0_HOVER_BG;
+            selectedBg = LEVEL0_SELECTED_BG;
+            selectedFg = LEVEL0_SELECTED_FG;
+        } else {
+            normalBg = new Color(255, 255, 255, 18);
+            normalFg = LEVEL1_NORMAL_FG;
+            hoverBg = LEVEL1_HOVER_BG;
+            selectedBg = LEVEL1_SELECTED_BG;
+            selectedFg = LEVEL1_SELECTED_FG;
+        }
+
+        setBackground(normalBg);
+        setForeground(normalFg);
         addChangeListener(this);
     }
 
     @Override
     public void stateChanged(ChangeEvent e) {
         if (isSelected()) {
-            setBackground(SELECTED_BG);
-            setForeground(SELECTED_FG);
+            setBackground(selectedBg);
+            setForeground(selectedFg);
         } else if (getModel().isRollover()) {
-            setBackground(HOVER_BG);
+            setBackground(hoverBg);
             setForeground(Color.WHITE);
         } else {
-            setBackground(new Color(255, 255, 255, 20));
-            setForeground(NORMAL_FG);
+            setBackground(normalBg);
+            setForeground(normalFg);
         }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
@@ -112,16 +112,31 @@ public class ShellFrame extends JFrame {
         ButtonGroup grp = new ButtonGroup();
         NavButton bHome = nav("Inicio", "ui/icons/home.svg", "home");
         NavButton bInv = nav("Inventario", "ui/icons/inventory.svg", "inventario");
-        NavButton bMov = nav("Movimientos", "ui/icons/movements.svg", "movimientos");
+        NavButton bMov = nav("Movimientos", "ui/icons/movements.svg", "movimientos", 1);
         NavButton bInf = nav("Informes", "ui/icons/reports.svg", "reportes");
         NavButton bTra = nav("Trámites", "ui/icons/tramites.svg", "tramites");
         NavButton bFin = nav("Finanzas", "ui/icons/finanzas.svg", "finanzas");
 
-        for (NavButton b : new NavButton[]{bHome, bInv, bMov, bInf, bTra, bFin}) {
-            grp.add(b);
-            menu.add(b);
-            menu.add(Box.createVerticalStrut(8));
-        }
+        grp.add(bHome);
+        grp.add(bInv);
+        grp.add(bMov);
+        grp.add(bInf);
+        grp.add(bTra);
+        grp.add(bFin);
+
+        menu.add(bHome);
+        menu.add(Box.createVerticalStrut(8));
+        menu.add(bInv);
+        menu.add(Box.createVerticalStrut(4));
+        menu.add(bMov);
+        menu.add(Box.createVerticalStrut(12));
+        menu.add(bInf);
+        menu.add(Box.createVerticalStrut(8));
+        menu.add(bTra);
+        menu.add(Box.createVerticalStrut(8));
+        menu.add(bFin);
+        menu.add(Box.createVerticalGlue());
+
         bHome.setSelected(true);
         side.add(menu, BorderLayout.CENTER);
 
@@ -142,7 +157,11 @@ public class ShellFrame extends JFrame {
     }
 
     private NavButton nav(String text, String icon, String key) {
-        NavButton btn = new NavButton(text, icon);
+        return nav(text, icon, key, 0);
+    }
+
+    private NavButton nav(String text, String icon, String key, int level) {
+        NavButton btn = new NavButton(text, icon, level);
         btn.addActionListener(e -> {
             lblTitle.setText(text);
             cardLayout.show(cards, key);


### PR DESCRIPTION
## Summary
- Rebuild the home dashboard with the greeting header, alert banner, KPI cards, activity lists, and quick access buttons that mirror the provided design
- Redesign the trámites workspace with styled tabs, detail form, recent/antique summaries, and an active trámites table featuring filters, badges, and export action
- Update the shell sidebar to support nested navigation styling so Movimientos appears as a child entry under Inventario

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to resolve junit BOM from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dc27d57e40832a99cf2888cb674269