### PR TITLE
Implement inventory business rules and dashboard navigation

### DIFF
--- a/db/migrations/003_inventario_tipo_ubicacion.sql
+++ b/db/migrations/003_inventario_tipo_ubicacion.sql
@@ -1,0 +1,16 @@
+-- tipo de ítem
+ALTER TABLE insumo
+  ADD COLUMN tipo ENUM('INSUMO','BIEN') NOT NULL DEFAULT 'INSUMO';
+
+-- catálogo de ubicaciones
+CREATE TABLE IF NOT EXISTS ubicacion (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(100) UNIQUE NOT NULL
+);
+
+INSERT IGNORE INTO ubicacion(nombre) VALUES
+ ('Sede Central'),('El Zanjón'),('Parque Industrial');
+
+-- permitir cantidades fraccionadas en movimientos
+ALTER TABLE movimiento
+  MODIFY COLUMN cantidad DECIMAL(12,2) NOT NULL;

--- a/src/main/java/ar/edu/unse/siga/config/AppServices.java
+++ b/src/main/java/ar/edu/unse/siga/config/AppServices.java
@@ -4,10 +4,12 @@ import ar.edu.unse.siga.persistence.dao.CategoriaDao;
 import ar.edu.unse.siga.persistence.dao.InsumoDao;
 import ar.edu.unse.siga.persistence.dao.MovimientoDao;
 import ar.edu.unse.siga.persistence.dao.TramiteDao;
+import ar.edu.unse.siga.persistence.dao.UbicacionDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcInsumoDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcMovimientoDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcCategoriaDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcTramiteDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcUbicacionDao;
 
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
@@ -24,11 +26,12 @@ public final class AppServices {
         InsumoDao insumoDao = new JdbcInsumoDao();
         MovimientoDao movDao = new JdbcMovimientoDao();
         CategoriaDao categoriaDao = new JdbcCategoriaDao();
+        UbicacionDao ubicacionDao = new JdbcUbicacionDao();
         TramiteDao tramDao = new JdbcTramiteDao();
 
 
         // Services (constructor con las dependencias que usa)
-        inventarioService = new InventarioService(insumoDao, movDao, categoriaDao);
+        inventarioService = new InventarioService(insumoDao, movDao, categoriaDao, ubicacionDao);
         tramiteService    = new TramiteService(tramDao);
         
         

--- a/src/main/java/ar/edu/unse/siga/domain/Insumo.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Insumo.java
@@ -12,6 +12,7 @@ public class Insumo {
     private Integer stockMinimo;
     private String ubicacion;
     private String estado;           // ACTIVO / INACTIVO
+    private String tipo;             // INSUMO / BIEN
     private Instant createdAt;       // timestamp de creación (BD)
     private LocalDate fechaAlta;     // vista amigable para informes
 
@@ -37,6 +38,9 @@ public class Insumo {
 
     public String getEstado() { return estado; }
     public void setEstado(String estado) { this.estado = estado; }
+
+    public String getTipo() { return tipo; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
@@ -11,7 +11,7 @@ public class Movimiento {
     private Long id;
     private Insumo insumo;
     private String tipo; // ENTRADA / SALIDA
-    private Integer cantidad;
+    private java.math.BigDecimal cantidad;
     private String destinoFuente;
     private LocalDateTime fecha;
     private Usuario usuario;
@@ -24,8 +24,8 @@ public class Movimiento {
     public void setInsumo(Insumo insumo) { this.insumo = insumo; }
     public String getTipo() { return tipo; }
     public void setTipo(String tipo) { this.tipo = tipo; }
-    public Integer getCantidad() { return cantidad; }
-    public void setCantidad(Integer cantidad) { this.cantidad = cantidad; }
+    public java.math.BigDecimal getCantidad() { return cantidad; }
+    public void setCantidad(java.math.BigDecimal cantidad) { this.cantidad = cantidad; }
     public String getDestinoFuente() { return destinoFuente; }
     public void setDestinoFuente(String destinoFuente) { this.destinoFuente = destinoFuente; }
     public LocalDateTime getFecha() { return fecha; }

--- a/src/main/java/ar/edu/unse/siga/domain/Ubicacion.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Ubicacion.java
@@ -1,0 +1,36 @@
+package ar.edu.unse.siga.domain;
+
+import java.util.Objects;
+
+public class Ubicacion {
+    private Integer id;
+    private String nombre;
+
+    public Ubicacion() {}
+
+    public Ubicacion(Integer id, String nombre) {
+        this.id = id;
+        this.nombre = nombre;
+    }
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Ubicacion)) return false;
+        Ubicacion that = (Ubicacion) o;
+        return Objects.equals(id, that.id) && Objects.equals(nombre, that.nombre);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(id, nombre);
+    }
+
+    @Override public String toString() {
+        return nombre == null ? "" : nombre;
+    }
+}

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/InsumoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/InsumoDao.java
@@ -9,6 +9,7 @@ public interface InsumoDao {
     void update(Insumo insumo);
     void softDelete(Long id);
     Optional<Insumo> findByCodigo(String codigo);
+    Optional<Insumo> findById(Long id);
     List<Insumo> listAll();
 }
 

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/MovimientoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/MovimientoDao.java
@@ -10,10 +10,12 @@ public interface MovimientoDao {
     // ya lo agregamos antes:
     java.util.List<Movimiento> ultimosPorInsumo(long insumoId, int limit);
 
-    // NUEVO: consultar stock actual de un insumo
-    int stockActual(long insumoId);
-    // Totales por insumo
-int totalEntradas(long insumoId);
-int totalSalidas(long insumoId);
+    java.math.BigDecimal stockActual(long insumoId);
+    java.math.BigDecimal totalEntradas(long insumoId);
+    java.math.BigDecimal totalSalidas(long insumoId);
+
+    java.util.List<Movimiento> buscarPorFechaYTipo(java.time.LocalDateTime desde,
+                                                   java.time.LocalDateTime hasta,
+                                                   String tipo);
 
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/UbicacionDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/UbicacionDao.java
@@ -1,0 +1,9 @@
+package ar.edu.unse.siga.persistence.dao;
+
+import ar.edu.unse.siga.domain.Ubicacion;
+
+import java.util.List;
+
+public interface UbicacionDao {
+    List<Ubicacion> listAll();
+}

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcInsumoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcInsumoDao.java
@@ -26,6 +26,11 @@ public class JdbcInsumoDao implements InsumoDao {
         i.setStockMinimo(rs.getInt("stock_minimo"));
         i.setUbicacion(rs.getString("ubicacion"));
         i.setEstado(rs.getString("estado"));
+        try {
+            i.setTipo(rs.getString("tipo"));
+        } catch (SQLException ignore) {
+            i.setTipo("INSUMO");
+        }
 
         // created_at → fechaAlta
         Timestamp ts = safeGetTimestamp(rs, "created_at");
@@ -62,8 +67,8 @@ public class JdbcInsumoDao implements InsumoDao {
     @Override
     public Long create(Insumo insumo) {
         final String sql = """
-            INSERT INTO insumo(codigo, descripcion, categoria_id, stock_minimo, ubicacion, estado)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO insumo(codigo, descripcion, categoria_id, stock_minimo, ubicacion, estado, tipo)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         """;
         try (Connection cn = DataSourceFactory.getConnection();
              PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
@@ -81,6 +86,7 @@ public class JdbcInsumoDao implements InsumoDao {
             ps.setInt(4, insumo.getStockMinimo() == null ? 0 : insumo.getStockMinimo());
             ps.setString(5, insumo.getUbicacion());
             ps.setString(6, insumo.getEstado() == null ? "ACTIVO" : insumo.getEstado());
+            ps.setString(7, normalizeTipo(insumo.getTipo()));
 
             ps.executeUpdate();
 
@@ -111,7 +117,8 @@ public class JdbcInsumoDao implements InsumoDao {
                 categoria_id = ?,
                 stock_minimo = ?,
                 ubicacion = ?,
-                estado = ?
+                estado = ?,
+                tipo = ?
             WHERE id = ?
         """;
         try (Connection cn = DataSourceFactory.getConnection();
@@ -130,7 +137,8 @@ public class JdbcInsumoDao implements InsumoDao {
             ps.setInt(4, insumo.getStockMinimo() == null ? 0 : insumo.getStockMinimo());
             ps.setString(5, insumo.getUbicacion());
             ps.setString(6, insumo.getEstado() == null ? "ACTIVO" : insumo.getEstado());
-            ps.setLong(7, insumo.getId());
+            ps.setString(7, normalizeTipo(insumo.getTipo()));
+            ps.setLong(8, insumo.getId());
 
             ps.executeUpdate();
 
@@ -192,6 +200,32 @@ public class JdbcInsumoDao implements InsumoDao {
 
         } catch (SQLException e) {
             throw new RuntimeException("Error listando insumos", e);
+        }
+    }
+
+    private String normalizeTipo(String tipo) {
+        if (tipo == null) return "INSUMO";
+        String up = tipo.trim().toUpperCase();
+        return ("BIEN".equals(up)) ? "BIEN" : "INSUMO";
+    }
+
+    @Override
+    public Optional<Insumo> findById(Long id) {
+        final String sql = """
+            SELECT i.*, c.nombre AS categoria_nombre
+            FROM insumo i
+            JOIN categoria c ON c.id = i.categoria_id
+            WHERE i.id = ?
+        """;
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setLong(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) return Optional.of(mapRow(rs));
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error buscando insumo por id: " + id, e);
         }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
@@ -6,12 +6,18 @@ import ar.edu.unse.siga.domain.Usuario;
 import ar.edu.unse.siga.persistence.DataSourceFactory;
 import ar.edu.unse.siga.persistence.dao.MovimientoDao;
 
+import java.math.BigDecimal;
 import java.sql.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JdbcMovimientoDao implements MovimientoDao {
 
-    private int stockActual(Connection cn, long insumoId) throws SQLException {
+    private static final String ENTRADA = "ENTRADA";
+    private static final String SALIDA = "SALIDA";
+
+    private BigDecimal stockActual(Connection cn, long insumoId) throws SQLException {
         final String sql = """
                 SELECT COALESCE(SUM(CASE WHEN tipo='ENTRADA' THEN cantidad ELSE -cantidad END),0) AS stock
                 FROM movimiento WHERE insumo_id = ?
@@ -20,18 +26,10 @@ public class JdbcMovimientoDao implements MovimientoDao {
             ps.setLong(1, insumoId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return rs.getInt("stock");
+                    BigDecimal stock = rs.getBigDecimal("stock");
+                    return stock == null ? BigDecimal.ZERO : stock;
                 }
-                return 0;
-            }
-        }
-    }
-
-    private boolean existeInsumo(Connection cn, long insumoId) throws SQLException {
-        try (PreparedStatement ps = cn.prepareStatement("SELECT 1 FROM insumo WHERE id=?")) {
-            ps.setLong(1, insumoId);
-            try (ResultSet rs = ps.executeQuery()) {
-                return rs.next();
+                return BigDecimal.ZERO;
             }
         }
     }
@@ -41,51 +39,49 @@ public class JdbcMovimientoDao implements MovimientoDao {
         if (m == null || m.getInsumo() == null || m.getInsumo().getId() == null) {
             throw new IllegalArgumentException("Insumo no especificado.");
         }
-        if (m.getCantidad() == null || m.getCantidad() <= 0) {
+        if (m.getCantidad() == null || m.getCantidad().compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Cantidad inválida.");
         }
-        if (m.getTipo() == null || (!m.getTipo().equalsIgnoreCase("ENTRADA") && !m.getTipo().equalsIgnoreCase("SALIDA"))) {
+        if (m.getTipo() == null
+                || (!ENTRADA.equalsIgnoreCase(m.getTipo()) && !SALIDA.equalsIgnoreCase(m.getTipo()))) {
             throw new IllegalArgumentException("Tipo de movimiento inválido.");
         }
 
         final String insertSql = """
-        INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, fecha, usuario_id)
-        VALUES (?, ?, ?, ?, ?, ?)
-    """;
+            INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, fecha, usuario_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """;
 
         try (Connection cn = DataSourceFactory.getConnection()) {
             boolean originalAutoCommit = cn.getAutoCommit();
             try {
                 cn.setAutoCommit(false);
 
-                int actual = stockActual(cn, m.getInsumo().getId());
-                if (m.getTipo().equalsIgnoreCase("SALIDA") && m.getCantidad() > actual) {
-                    throw new IllegalStateException(
-                            String.format(
-                                    "No hay suficiente stock para realizar esta salida.%n%n"
-                                            + "Cantidad disponible: %d%n"
-                                            + "Cantidad solicitada: %d%n%n"
-                                            + "Podés registrar una cantidad menor o agregar más stock con una ENTRADA.",
-                                    actual, m.getCantidad()
-                            )
-                    );
+                BigDecimal actual = stockActual(cn, m.getInsumo().getId());
+                if (SALIDA.equalsIgnoreCase(m.getTipo()) && m.getCantidad().compareTo(actual) > 0) {
+                    throw new IllegalStateException(String.format(
+                            "No hay suficiente stock para realizar esta salida.%n%n" +
+                                    "Cantidad disponible: %s%nCantidad solicitada: %s%n%n" +
+                                    "Podés registrar una cantidad menor o agregar más stock con una ENTRADA.",
+                            actual.stripTrailingZeros().toPlainString(),
+                            m.getCantidad().stripTrailingZeros().toPlainString()));
                 }
 
                 if (m.getFecha() == null) {
-                    m.setFecha(java.time.LocalDateTime.now());
+                    m.setFecha(LocalDateTime.now());
                 }
 
                 try (PreparedStatement ps = cn.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS)) {
                     ps.setLong(1, m.getInsumo().getId());
                     ps.setString(2, m.getTipo().toUpperCase());
-                    ps.setInt(3, m.getCantidad());
+                    ps.setBigDecimal(3, m.getCantidad());
                     ps.setString(4, m.getDestinoFuente());
-                    ps.setTimestamp(5, java.sql.Timestamp.valueOf(m.getFecha()));
+                    ps.setTimestamp(5, Timestamp.valueOf(m.getFecha()));
 
                     if (m.getUsuario() != null && m.getUsuario().getId() != null) {
                         ps.setLong(6, m.getUsuario().getId());
                     } else {
-                        ps.setNull(6, java.sql.Types.BIGINT);
+                        ps.setNull(6, Types.BIGINT);
                     }
 
                     ps.executeUpdate();
@@ -101,22 +97,13 @@ public class JdbcMovimientoDao implements MovimientoDao {
                 cn.rollback();
                 throw new RuntimeException("No se pudo registrar el movimiento.");
             } catch (SQLException e) {
-                try {
-                    cn.rollback();
-                } catch (SQLException ignored) {
-                }
+                try { cn.rollback(); } catch (SQLException ignored) {}
                 throw new RuntimeException("Error registrando movimiento", e);
             } catch (RuntimeException e) {
-                try {
-                    cn.rollback();
-                } catch (SQLException ignored) {
-                }
+                try { cn.rollback(); } catch (SQLException ignored) {}
                 throw e;
             } finally {
-                try {
-                    cn.setAutoCommit(originalAutoCommit);
-                } catch (SQLException ignored) {
-                }
+                try { cn.setAutoCommit(originalAutoCommit); } catch (SQLException ignored) {}
             }
         } catch (SQLException e) {
             throw new RuntimeException("Error registrando movimiento", e);
@@ -124,16 +111,17 @@ public class JdbcMovimientoDao implements MovimientoDao {
     }
 
     @Override
-    public java.util.List<Movimiento> ultimosPorInsumo(long insumoId, int limit) {
+    public List<Movimiento> ultimosPorInsumo(long insumoId, int limit) {
         final String sql = """
             SELECT id, insumo_id, tipo, cantidad, destino_fuente, fecha, usuario_id
             FROM movimiento
             WHERE insumo_id = ?
             ORDER BY fecha DESC, id DESC
             LIMIT ?
-            """;
-        var lista = new java.util.ArrayList<Movimiento>();
-        try (Connection cn = DataSourceFactory.getConnection(); PreparedStatement ps = cn.prepareStatement(sql)) {
+        """;
+        var lista = new ArrayList<Movimiento>();
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
 
             ps.setLong(1, insumoId);
             ps.setInt(2, Math.max(1, limit));
@@ -142,16 +130,16 @@ public class JdbcMovimientoDao implements MovimientoDao {
                     Movimiento m = new Movimiento();
                     m.setId(rs.getLong("id"));
 
-                    // set insumo con solo el id
                     Insumo ins = new Insumo();
                     ins.setId(rs.getLong("insumo_id"));
                     m.setInsumo(ins);
 
                     m.setTipo(rs.getString("tipo"));
-                    m.setCantidad(rs.getInt("cantidad"));
+                    BigDecimal cant = rs.getBigDecimal("cantidad");
+                    m.setCantidad(cant == null ? BigDecimal.ZERO : cant);
                     m.setDestinoFuente(rs.getString("destino_fuente"));
 
-                    var ts = rs.getTimestamp("fecha");
+                    Timestamp ts = rs.getTimestamp("fecha");
                     if (ts != null) {
                         m.setFecha(ts.toLocalDateTime());
                     }
@@ -173,60 +161,129 @@ public class JdbcMovimientoDao implements MovimientoDao {
     }
 
     @Override
-    public int stockActual(long insumoId) {
-        final String sql = """
-        SELECT COALESCE(SUM(CASE
-            WHEN tipo='ENTRADA' THEN cantidad
-            WHEN tipo='SALIDA'  THEN -cantidad
-            ELSE 0 END), 0) AS stock
-        FROM movimiento
-        WHERE insumo_id = ?
-    """;
-        try (Connection cn = DataSourceFactory.getConnection(); PreparedStatement ps = cn.prepareStatement(sql)) {
-            ps.setLong(1, insumoId);
-            try (ResultSet rs = ps.executeQuery()) {
-                return rs.next() ? rs.getInt("stock") : 0;
-            }
+    public BigDecimal stockActual(long insumoId) {
+        try (Connection cn = DataSourceFactory.getConnection()) {
+            return stockActual(cn, insumoId);
         } catch (SQLException e) {
             throw new RuntimeException("Error calculando stock actual", e);
         }
     }
-    
+
     @Override
-public int totalEntradas(long insumoId) {
-    final String sql = """
-        SELECT COALESCE(SUM(cantidad),0) AS total
-        FROM movimiento
-        WHERE insumo_id = ? AND UPPER(tipo) = 'ENTRADA'
-    """;
-    try (Connection cn = DataSourceFactory.getConnection();
-         PreparedStatement ps = cn.prepareStatement(sql)) {
-        ps.setLong(1, insumoId);
-        try (ResultSet rs = ps.executeQuery()) {
-            return rs.next() ? rs.getInt("total") : 0;
+    public BigDecimal totalEntradas(long insumoId) {
+        final String sql = """
+            SELECT COALESCE(SUM(cantidad),0) AS total
+            FROM movimiento
+            WHERE insumo_id = ? AND UPPER(tipo) = 'ENTRADA'
+        """;
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setLong(1, insumoId);
+            try (ResultSet rs = ps.executeQuery()) {
+                BigDecimal total = rs.next() ? rs.getBigDecimal("total") : BigDecimal.ZERO;
+                return total == null ? BigDecimal.ZERO : total;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error consultando total de ENTRADAS", e);
         }
-    } catch (SQLException e) {
-        throw new RuntimeException("Error consultando total de ENTRADAS", e);
     }
-}
 
-@Override
-public int totalSalidas(long insumoId) {
-    final String sql = """
-        SELECT COALESCE(SUM(cantidad),0) AS total
-        FROM movimiento
-        WHERE insumo_id = ? AND UPPER(tipo) = 'SALIDA'
-    """;
-    try (Connection cn = DataSourceFactory.getConnection();
-         PreparedStatement ps = cn.prepareStatement(sql)) {
-        ps.setLong(1, insumoId);
-        try (ResultSet rs = ps.executeQuery()) {
-            return rs.next() ? rs.getInt("total") : 0;
+    @Override
+    public BigDecimal totalSalidas(long insumoId) {
+        final String sql = """
+            SELECT COALESCE(SUM(cantidad),0) AS total
+            FROM movimiento
+            WHERE insumo_id = ? AND UPPER(tipo) = 'SALIDA'
+        """;
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setLong(1, insumoId);
+            try (ResultSet rs = ps.executeQuery()) {
+                BigDecimal total = rs.next() ? rs.getBigDecimal("total") : BigDecimal.ZERO;
+                return total == null ? BigDecimal.ZERO : total;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error consultando total de SALIDAS", e);
         }
-    } catch (SQLException e) {
-        throw new RuntimeException("Error consultando total de SALIDAS", e);
     }
-}
 
+    @Override
+    public List<Movimiento> buscarPorFechaYTipo(LocalDateTime desde, LocalDateTime hasta, String tipo) {
+        StringBuilder sql = new StringBuilder("""
+            SELECT m.id, m.insumo_id, m.tipo, m.cantidad, m.destino_fuente, m.fecha, m.usuario_id,
+                   i.codigo, i.descripcion, i.ubicacion, i.tipo AS insumo_tipo, i.estado
+            FROM movimiento m
+            JOIN insumo i ON i.id = m.insumo_id
+            WHERE 1 = 1
+        """);
 
+        List<Object> params = new ArrayList<>();
+
+        if (tipo != null && !tipo.isBlank() && !"TODOS".equalsIgnoreCase(tipo)) {
+            sql.append(" AND UPPER(m.tipo) = ?");
+            params.add(tipo.trim().toUpperCase());
+        }
+        if (desde != null) {
+            sql.append(" AND m.fecha >= ?");
+            params.add(Timestamp.valueOf(desde));
+        }
+        if (hasta != null) {
+            sql.append(" AND m.fecha <= ?");
+            params.add(Timestamp.valueOf(hasta));
+        }
+
+        sql.append(" ORDER BY m.fecha DESC, m.id DESC");
+
+        var lista = new ArrayList<Movimiento>();
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql.toString())) {
+
+            for (int i = 0; i < params.size(); i++) {
+                Object value = params.get(i);
+                if (value instanceof Timestamp ts) {
+                    ps.setTimestamp(i + 1, ts);
+                } else if (value instanceof String s) {
+                    ps.setString(i + 1, s);
+                } else {
+                    ps.setObject(i + 1, value);
+                }
+            }
+
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Movimiento m = new Movimiento();
+                    m.setId(rs.getLong("id"));
+                    m.setTipo(rs.getString("tipo"));
+                    BigDecimal cant = rs.getBigDecimal("cantidad");
+                    m.setCantidad(cant == null ? BigDecimal.ZERO : cant);
+                    m.setDestinoFuente(rs.getString("destino_fuente"));
+                    Timestamp ts = rs.getTimestamp("fecha");
+                    if (ts != null) {
+                        m.setFecha(ts.toLocalDateTime());
+                    }
+
+                    long usuarioId = rs.getLong("usuario_id");
+                    if (!rs.wasNull()) {
+                        Usuario u = new Usuario();
+                        u.setId(usuarioId);
+                        m.setUsuario(u);
+                    }
+
+                    Insumo ins = new Insumo();
+                    ins.setId(rs.getLong("insumo_id"));
+                    ins.setCodigo(rs.getString("codigo"));
+                    ins.setDescripcion(rs.getString("descripcion"));
+                    ins.setUbicacion(rs.getString("ubicacion"));
+                    ins.setTipo(rs.getString("insumo_tipo"));
+                    ins.setEstado(rs.getString("estado"));
+                    m.setInsumo(ins);
+
+                    lista.add(m);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error buscando movimientos", e);
+        }
+        return lista;
+    }
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcUbicacionDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcUbicacionDao.java
@@ -1,0 +1,34 @@
+package ar.edu.unse.siga.persistence.jdbc;
+
+import ar.edu.unse.siga.domain.Ubicacion;
+import ar.edu.unse.siga.persistence.DataSourceFactory;
+import ar.edu.unse.siga.persistence.dao.UbicacionDao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JdbcUbicacionDao implements UbicacionDao {
+
+    @Override
+    public List<Ubicacion> listAll() {
+        final String sql = "SELECT id, nombre FROM ubicacion ORDER BY nombre";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            List<Ubicacion> list = new ArrayList<>();
+            while (rs.next()) {
+                Ubicacion u = new Ubicacion();
+                u.setId(rs.getInt("id"));
+                u.setNombre(rs.getString("nombre"));
+                list.add(u);
+            }
+            return list;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error listando ubicaciones", e);
+        }
+    }
+}

--- a/src/main/java/ar/edu/unse/siga/service/InventarioService.java
+++ b/src/main/java/ar/edu/unse/siga/service/InventarioService.java
@@ -4,12 +4,17 @@ import ar.edu.unse.siga.common.CurrentSession;
 import ar.edu.unse.siga.domain.Categoria;
 import ar.edu.unse.siga.domain.Insumo;
 import ar.edu.unse.siga.domain.Movimiento;
+import ar.edu.unse.siga.domain.Ubicacion;
 import ar.edu.unse.siga.domain.Usuario;
 import ar.edu.unse.siga.persistence.dao.CategoriaDao;
 import ar.edu.unse.siga.persistence.dao.InsumoDao;
 import ar.edu.unse.siga.persistence.dao.MovimientoDao;
+import ar.edu.unse.siga.persistence.dao.UbicacionDao;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -19,11 +24,16 @@ public class InventarioService {
     private final InsumoDao insumoDao;
     private final MovimientoDao movimientoDao;
     private final CategoriaDao categoriaDao;
+    private final UbicacionDao ubicacionDao;
 
-    public InventarioService(InsumoDao insumoDao, MovimientoDao movimientoDao, CategoriaDao categoriaDao) {
+    public InventarioService(InsumoDao insumoDao,
+                             MovimientoDao movimientoDao,
+                             CategoriaDao categoriaDao,
+                             UbicacionDao ubicacionDao) {
         this.insumoDao = insumoDao;
         this.movimientoDao = movimientoDao;
         this.categoriaDao = categoriaDao;
+        this.ubicacionDao = ubicacionDao;
     }
 
     // === Categorías ===
@@ -31,36 +41,98 @@ public class InventarioService {
         return categoriaDao.findAllOrderByNombre();
     }
 
+    public List<Ubicacion> listarUbicaciones() {
+        if (ubicacionDao == null) return java.util.List.of();
+        return ubicacionDao.listAll();
+    }
+
     // === Insumos ===
     public Long registrarInsumo(Insumo i) {
+        if (i == null) throw new IllegalArgumentException("Insumo inválido");
         if (i.getCodigo() == null || i.getCodigo().isBlank()) {
             throw new IllegalArgumentException("El código es obligatorio");
         }
         if (i.getDescripcion() == null || i.getDescripcion().isBlank()) {
             throw new IllegalArgumentException("La descripción es obligatoria");
         }
+        i.setEstado(normalizeEstado(i.getEstado()));
+        i.setTipo(normalizeTipo(i.getTipo()));
         return insumoDao.create(i);
     }
 
-    public void editarInsumo(Insumo i) { insumoDao.update(i); }
+    public void editarInsumo(Insumo i) {
+        if (i == null || i.getId() == null) {
+            throw new IllegalArgumentException("Insumo inválido");
+        }
+        Insumo original = insumoDao.findById(i.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Insumo no encontrado id=" + i.getId()));
 
-    public void bajaLogica(Long id) { insumoDao.softDelete(id); }
+        String nuevoEstado = normalizeEstado(i.getEstado());
+        String estadoOriginal = normalizeEstado(original.getEstado());
+        if (!estadoOriginal.equals(nuevoEstado) && !usuarioActualEsAdmin()) {
+            throw new IllegalStateException("Solo usuarios ADMIN pueden cambiar el estado del insumo.");
+        }
+
+        i.setEstado(nuevoEstado);
+        i.setTipo(normalizeTipo(i.getTipo()));
+        insumoDao.update(i);
+    }
+
+    public void bajaLogica(Long id) {
+        if (id == null) throw new IllegalArgumentException("Id requerido");
+        BigDecimal stock = movimientoDao.stockActual(id);
+        if (stock != null && stock.compareTo(BigDecimal.ZERO) > 0) {
+            throw new IllegalStateException("Stock actual: " + formatCantidad(stock)
+                    + ". No se puede dar de baja");
+        }
+        insumoDao.softDelete(id);
+    }
 
     public Optional<Insumo> buscarPorCodigo(String codigo) { return insumoDao.findByCodigo(codigo); }
 
     public List<Insumo> listarTodos() { return insumoDao.listAll(); }
 
     // === Movimientos ===
-    public Long registrarMovimiento(Long insumoId, String tipo, int cantidad, String destinoFuente) {
-        var insumo = insumoDao.listAll().stream()
-                .filter(i -> i.getId().equals(insumoId))
-                .findFirst()
+    public Long registrarMovimiento(Long insumoId, String tipo, BigDecimal cantidad, String destinoFuente) {
+        if (insumoId == null) {
+            throw new IllegalArgumentException("Insumo no especificado");
+        }
+        Insumo insumo = insumoDao.findById(insumoId)
                 .orElseThrow(() -> new IllegalArgumentException("Insumo no encontrado id=" + insumoId));
+
+        if (!"ACTIVO".equalsIgnoreCase(normalizeEstado(insumo.getEstado()))) {
+            throw new IllegalStateException("El insumo está INACTIVO; no se pueden registrar movimientos.");
+        }
+
+        String tipoNorm = tipo == null ? "" : tipo.trim().toUpperCase();
+        if (!tipoNorm.equals("ENTRADA") && !tipoNorm.equals("SALIDA")) {
+            throw new IllegalArgumentException("Tipo de movimiento inválido");
+        }
+
+        if (cantidad == null) {
+            throw new IllegalArgumentException("Cantidad inválida");
+        }
+        BigDecimal qty = cantidad.stripTrailingZeros();
+        if (qty.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("La cantidad debe ser mayor que cero");
+        }
+
+        boolean esBien = "BIEN".equalsIgnoreCase(normalizeTipo(insumo.getTipo()));
+        if (esBien && qty.scale() > 0) {
+            throw new IllegalArgumentException("Para Bienes patrimoniales, la cantidad debe ser un entero.");
+        }
+
+        BigDecimal stockActual = movimientoDao.stockActual(insumoId);
+        if (tipoNorm.equals("SALIDA") && qty.compareTo(stockActual) > 0) {
+            throw new IllegalStateException(String.format(
+                    "Stock insuficiente: actual %s, salida %s.",
+                    formatCantidad(stockActual), formatCantidad(qty)));
+        }
 
         Movimiento m = new Movimiento();
         m.setInsumo(insumo);
-        m.setTipo(tipo);
-        m.setCantidad(cantidad);
+        m.setTipo(tipoNorm);
+        m.setCantidad(qty);
         m.setDestinoFuente(destinoFuente);
 
         Usuario u = CurrentSession.getUser();
@@ -90,35 +162,42 @@ public class InventarioService {
 
     public static class StockCheckResult {
         public final Long insumoId;
-        public final Integer stockActual;
+        public final BigDecimal stockActual;
         public final Integer stockMinimo;
         public final boolean bajoMinimo;
 
-        public StockCheckResult(Long insumoId, Integer stockActual, Integer stockMinimo) {
+        public StockCheckResult(Long insumoId, BigDecimal stockActual, Integer stockMinimo) {
             this.insumoId = insumoId;
-            this.stockActual = stockActual;
+            this.stockActual = stockActual == null ? BigDecimal.ZERO : stockActual;
             this.stockMinimo = stockMinimo;
-            this.bajoMinimo = (stockActual != null && stockMinimo != null) && stockActual < stockMinimo;
+            this.bajoMinimo = stockMinimo != null
+                    && this.stockActual.compareTo(BigDecimal.valueOf(stockMinimo)) < 0;
         }
 
-        public static StockCheckResult of(Long insumoId, Integer actual, Integer minimo) {
+        public static StockCheckResult of(Long insumoId, BigDecimal actual, Integer minimo) {
             return new StockCheckResult(insumoId, actual, minimo);
         }
 
         public Long getInsumoId() { return insumoId; }
-        public Integer getStockActual() { return stockActual; }
+        public BigDecimal getStockActualDecimal() { return stockActual; }
+        public int getStockActual() { return stockActual.setScale(0, RoundingMode.DOWN).intValue(); }
         public Integer getStockMinimo() { return stockMinimo; }
         public boolean isBajoMinimo() { return bajoMinimo; }
     }
 
     // Consulta “entera” (para llamadas antiguas)
+    public BigDecimal stockActualExacto(long insumoId) {
+        BigDecimal stock = movimientoDao.stockActual(insumoId);
+        return stock == null ? BigDecimal.ZERO : stock;
+    }
+
     public int stockActual(long insumoId) {
-        return movimientoDao.stockActual(insumoId);
+        return stockActualExacto(insumoId).setScale(0, RoundingMode.DOWN).intValue();
     }
 
     // Para pantallas que quieren también el mínimo
     public StockCheckResult stockActual(Long insumoId) {
-        int actual = (insumoId == null) ? 0 : movimientoDao.stockActual(insumoId);
+        BigDecimal actual = (insumoId == null) ? BigDecimal.ZERO : stockActualExacto(insumoId);
         Integer minimo = null;
         if (insumoId != null) {
             minimo = insumoDao.listAll().stream()
@@ -137,16 +216,52 @@ public class InventarioService {
         return movimientoDao.ultimosPorInsumo(insumoId, limit);
     }
 
+    public List<Movimiento> movimientosPorFechaYTipo(LocalDate desde, LocalDate hasta, String tipo) {
+        LocalDateTime d1 = desde == null ? null : desde.atStartOfDay();
+        LocalDateTime d2 = hasta == null ? null : hasta.plusDays(1).atStartOfDay().minusNanos(1);
+        return movimientoDao.buscarPorFechaYTipo(d1, d2, tipo);
+    }
+
     // --- END API compatible con la UI ---
     
+    public BigDecimal totalEntradasExactas(long insumoId) {
+        BigDecimal total = movimientoDao.totalEntradas(insumoId);
+        return total == null ? BigDecimal.ZERO : total;
+    }
+
+    public BigDecimal totalSalidasExactas(long insumoId) {
+        BigDecimal total = movimientoDao.totalSalidas(insumoId);
+        return total == null ? BigDecimal.ZERO : total;
+    }
+
     public int totalEntradasDeInsumo(long insumoId) {
-    return movimientoDao.totalEntradas(insumoId);
-}
+        return totalEntradasExactas(insumoId).setScale(0, RoundingMode.DOWN).intValue();
+    }
 
-public int totalSalidasDeInsumo(long insumoId) {
-    return movimientoDao.totalSalidas(insumoId);
-}
+    public int totalSalidasDeInsumo(long insumoId) {
+        return totalSalidasExactas(insumoId).setScale(0, RoundingMode.DOWN).intValue();
+    }
 
-// ya tenés public int stockActual(long insumoId) { ... } -> se reutiliza
+    private String normalizeEstado(String estado) {
+        if (estado == null || estado.isBlank()) return "ACTIVO";
+        String up = estado.trim().toUpperCase();
+        return up.equals("INACTIVO") ? "INACTIVO" : "ACTIVO";
+    }
 
+    private String normalizeTipo(String tipo) {
+        if (tipo == null || tipo.isBlank()) return "INSUMO";
+        String up = tipo.trim().toUpperCase();
+        return up.equals("BIEN") ? "BIEN" : "INSUMO";
+    }
+
+    private boolean usuarioActualEsAdmin() {
+        Usuario u = CurrentSession.getUser();
+        if (u == null || u.getRol() == null || u.getRol().getNombre() == null) return false;
+        return "ADMIN".equalsIgnoreCase(u.getRol().getNombre());
+    }
+
+    private String formatCantidad(BigDecimal valor) {
+        if (valor == null) return "0";
+        return valor.stripTrailingZeros().toPlainString();
+    }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/AppLauncher.java
+++ b/src/main/java/ar/edu/unse/siga/ui/AppLauncher.java
@@ -6,7 +6,8 @@ import ar.edu.unse.siga.persistence.jdbc.*;
 import ar.edu.unse.siga.service.AuthService;
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
-import ar.edu.unse.siga.persistence.jdbc.JdbcCategoriaDao;  
+import ar.edu.unse.siga.persistence.jdbc.JdbcCategoriaDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcUbicacionDao;
 
 import javax.swing.*;
 
@@ -20,11 +21,12 @@ public class AppLauncher {
         MovimientoDao movDao = new JdbcMovimientoDao();
         UsuarioDao usuarioDao = new JdbcUsuarioDao();
         TramiteDao tramiteDao = new JdbcTramiteDao();
+        CategoriaDao categoriaDao = new JdbcCategoriaDao();
+        UbicacionDao ubicacionDao = new JdbcUbicacionDao();
 
         // Services
         AuthService auth = new AuthService(usuarioDao);
-var categoriaDao = new JdbcCategoriaDao();
-InventarioService inv = new InventarioService(insumoDao, movDao, categoriaDao);
+        InventarioService inv = new InventarioService(insumoDao, movDao, categoriaDao, ubicacionDao);
         TramiteService tra = new TramiteService(tramiteDao);
         
         

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/MovimientoDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/MovimientoDialog.java
@@ -1,163 +1,163 @@
 package ar.edu.unse.siga.ui.inventario;
 
+import ar.edu.unse.siga.ui.base.CardPanel;
+
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.text.DefaultFormatterFactory;
-import javax.swing.text.NumberFormatter;
 import java.awt.*;
-import java.text.DecimalFormat;
-import java.text.ParseException;
+import java.math.BigDecimal;
+import java.util.List;
 
-/**
- * Diálogo reutilizable para registrar un movimiento (ENTRADA / SALIDA).
- * - Campo Cantidad SOLO numérico (1 .. 1_000_000)
- * - Muestra "Destino/Fuente" SOLO cuando el tipo es SALIDA
- */
 public class MovimientoDialog extends JDialog {
 
     private final JLabel lblContexto = new JLabel();
-    private final JComboBox<String> cbTipo = new JComboBox<>(new String[]{"ENTRADA", "SALIDA"});
-    private final JSpinner spCantidad = new JSpinner(new SpinnerNumberModel(1, 1, 1_000_000, 1));
+    private final JLabel lblTipo = new JLabel();
+    private final JTextField txtCantidad = new JTextField();
+    private final JComboBox<String> cbDestino = new JComboBox<>();
 
-    // Campo condicional (solo visible para SALIDA)
-    private final JLabel lblDestino = new JLabel("Destino/Fuente:");
-    private final JComboBox<String> cbDestino = new JComboBox<>(new String[]{
-            "Sede Central",
-            "Sede Zanjón",
-            "Sede Parque Industrial"
-    });
-
+    private final String tipoMovimiento;
+    private final boolean allowDecimal;
     private boolean accepted = false;
-    private final JPanel panel = new JPanel(new GridLayout(0, 2, 8, 8));
 
-    public MovimientoDialog(Window owner) {
-        this(owner, null, "ENTRADA", null, 1);
-    }
+    public MovimientoDialog(Window owner,
+                            String contexto,
+                            String tipoMovimiento,
+                            boolean allowDecimal,
+                            List<String> ubicaciones) {
+        super(owner, "Registrar " + tipoMovimiento, ModalityType.APPLICATION_MODAL);
+        this.tipoMovimiento = tipoMovimiento == null ? "ENTRADA" : tipoMovimiento.trim().toUpperCase();
+        this.allowDecimal = allowDecimal;
 
-    public MovimientoDialog(Window owner, String contexto, String tipoInicial, String destinoInicial, int cantidadInicial) {
-        super(owner, "Registrar Movimiento", ModalityType.APPLICATION_MODAL);
         setLayout(new BorderLayout(10, 10));
+        setMinimumSize(new Dimension(420, 220));
 
-        // --- encabezado opcional ---
         if (contexto != null && !contexto.isBlank()) {
             lblContexto.setText(contexto);
-            lblContexto.setFont(lblContexto.getFont().deriveFont(Font.BOLD));
-            lblContexto.setBorder(new EmptyBorder(10, 12, 0, 12));
+            lblContexto.setBorder(new EmptyBorder(12, 16, 0, 16));
             add(lblContexto, BorderLayout.NORTH);
         }
 
-        // --- panel central ---
-        panel.setBorder(new EmptyBorder(12, 16, 0, 16));
-        panel.add(new JLabel("Tipo:"));
-        panel.add(cbTipo);
-        panel.add(new JLabel("Cantidad:"));
-        panel.add(spCantidad);
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new GridBagLayout());
+        panel.setBorder(new EmptyBorder(16, 16, 0, 16));
 
-        // campo destino (solo se añade si tipo = SALIDA)
-        cbDestino.setEditable(false);
-        panel.add(lblDestino);
-        panel.add(cbDestino);
+        GridBagConstraints gc = new GridBagConstraints();
+        gc.gridx = 0;
+        gc.gridy = 0;
+        gc.anchor = GridBagConstraints.LINE_START;
+        gc.insets = new Insets(0, 0, 10, 0);
+
+        lblTipo.setText("Tipo: " + this.tipoMovimiento);
+        lblTipo.setFont(lblTipo.getFont().deriveFont(Font.BOLD));
+        panel.add(lblTipo, gc);
+
+        gc.gridy++;
+        panel.add(label("Cantidad"), gc);
+
+        gc.gridx = 1;
+        gc.fill = GridBagConstraints.HORIZONTAL;
+        gc.weightx = 1;
+        txtCantidad.putClientProperty("JTextField.placeholderText", allowDecimal ? "Ej: 3.5" : "Ej: 2");
+        panel.add(txtCantidad, gc);
+
+        if (esSalida()) {
+            gc.gridx = 0;
+            gc.gridy++;
+            gc.weightx = 0;
+            gc.fill = GridBagConstraints.NONE;
+            panel.add(label("Destino"), gc);
+
+            gc.gridx = 1;
+            gc.fill = GridBagConstraints.HORIZONTAL;
+            gc.weightx = 1;
+            cbDestino.putClientProperty("JComponent.roundRect", true);
+            panel.add(cbDestino, gc);
+
+            if (ubicaciones != null && !ubicaciones.isEmpty()) {
+                ubicaciones.forEach(cbDestino::addItem);
+            }
+        }
 
         add(panel, BorderLayout.CENTER);
 
-        // === Editor numérico ESTRICTO ===
-        JSpinner.NumberEditor numEd = new JSpinner.NumberEditor(spCantidad, "#");
-        spCantidad.setEditor(numEd);
-        JFormattedTextField tf = numEd.getTextField();
+        JButton btnAceptar = new JButton("Registrar");
+        JButton btnCancelar = new JButton("Cancelar");
+        Dimension size = new Dimension(130, 36);
+        btnAceptar.setPreferredSize(size);
+        btnCancelar.setPreferredSize(size);
 
-        NumberFormatter nf = new NumberFormatter(new DecimalFormat("#"));
-        nf.setValueClass(Integer.class);
-        nf.setAllowsInvalid(false);
-        nf.setCommitsOnValidEdit(true);
-        nf.setMinimum(1);
-        nf.setMaximum(1_000_000);
-
-        tf.setFormatterFactory(new DefaultFormatterFactory(nf));
-        tf.setColumns(8);
-
-        // --- botones ---
-        var ok = new JButton("Registrar");
-        var cancel = new JButton("Cancelar");
-        ok.setPreferredSize(new Dimension(110, 30));
-        cancel.setPreferredSize(new Dimension(110, 30));
-
-        ok.addActionListener(e -> {
-            accepted = true;
-            setVisible(false);
+        btnAceptar.addActionListener(e -> {
+            if (validarCantidad()) {
+                accepted = true;
+                setVisible(false);
+            }
         });
-        cancel.addActionListener(e -> setVisible(false));
+        btnCancelar.addActionListener(e -> setVisible(false));
 
-        var south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        south.setBorder(new EmptyBorder(8, 8, 8, 8));
-        south.add(cancel);
-        south.add(ok);
+        JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        south.setBorder(new EmptyBorder(0, 0, 12, 12));
+        south.add(btnCancelar);
+        south.add(btnAceptar);
         add(south, BorderLayout.SOUTH);
 
-        // --- valores iniciales ---
-        if (tipoInicial != null) {
-            cbTipo.setSelectedItem(tipoInicial);
-        }
-        if (destinoInicial != null) {
-            cbDestino.setSelectedItem(destinoInicial);
-        }
-        if (cantidadInicial > 0) {
-            spCantidad.setValue(cantidadInicial);
-        }
-
-        // comportamiento dinámico
-        cbTipo.addItemListener(e -> actualizarVisibilidadDestino());
-        actualizarVisibilidadDestino(); // inicial
-
-        setMinimumSize(new Dimension(680, getMinimumSize().height));
         pack();
         setLocationRelativeTo(owner);
     }
 
-    // ==== lógica para mostrar u ocultar el campo destino ====
-    private void actualizarVisibilidadDestino() {
-        String tipo = (String) cbTipo.getSelectedItem();
-        boolean esSalida = "SALIDA".equalsIgnoreCase(tipo);
-
-        lblDestino.setVisible(esSalida);
-        cbDestino.setVisible(esSalida);
-
-        // refresca la UI sin necesidad de recrear todo
-        panel.revalidate();
-        panel.repaint();
+    private JLabel label(String text) {
+        JLabel lbl = new JLabel(text);
+        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
+        return lbl;
     }
 
-    // ==== getters / setters ====
+    private boolean esSalida() {
+        return "SALIDA".equalsIgnoreCase(tipoMovimiento);
+    }
+
+    private boolean validarCantidad() {
+        try {
+            BigDecimal qty = getCantidad();
+            if (qty.compareTo(BigDecimal.ZERO) <= 0) {
+                JOptionPane.showMessageDialog(this, "La cantidad debe ser mayor a cero.", "Atención", JOptionPane.WARNING_MESSAGE);
+                return false;
+            }
+            if (!allowDecimal && qty.stripTrailingZeros().scale() > 0) {
+                JOptionPane.showMessageDialog(this, "La cantidad debe ser un entero.", "Atención", JOptionPane.WARNING_MESSAGE);
+                return false;
+            }
+            return true;
+        } catch (IllegalArgumentException ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Atención", JOptionPane.WARNING_MESSAGE);
+            return false;
+        }
+    }
+
     public boolean isAccepted() {
         return accepted;
     }
 
     public String getTipo() {
-        return (String) cbTipo.getSelectedItem();
+        return tipoMovimiento;
     }
 
-    public int getCantidad() {
+    public BigDecimal getCantidad() {
+        String text = txtCantidad.getText();
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Ingresá una cantidad válida.");
+        }
         try {
-            JComponent ed = spCantidad.getEditor();
-            if (ed instanceof JSpinner.DefaultEditor de) {
-                de.commitEdit();
-            }
-        } catch (ParseException ignore) {}
-        return ((Number) spCantidad.getValue()).intValue();
+            String normalized = text.replace(',', '.');
+            return new BigDecimal(normalized).stripTrailingZeros();
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Cantidad inválida.");
+        }
     }
 
     public String getDestinoFuente() {
-        String tipo = (String) cbTipo.getSelectedItem();
-        if ("SALIDA".equalsIgnoreCase(tipo)) {
-            return (String) cbDestino.getSelectedItem();
+        if (!esSalida()) {
+            return "";
         }
-        return ""; // si es entrada, devuelve vacío
-    }
-
-    public void setContexto(String texto) {
-        lblContexto.setText(texto);
-    }
-
-    public void setCantidad(int cant) {
-        spCantidad.setValue(Math.max(1, cant));
+        Object sel = cbDestino.getSelectedItem();
+        return sel == null ? "" : sel.toString();
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
@@ -10,13 +10,12 @@ import ar.edu.unse.siga.ui.base.CardPanel;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
-import java.text.NumberFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Consumer;
+import java.math.BigDecimal;
 
 /**
  * Dashboard de Inicio con métricas y actividad reciente dinámica.
@@ -30,13 +29,19 @@ public class HomePage extends JPanel {
     private final Usuario usuarioActual;
     private final InventarioService inventarioService;
     private final TramiteService tramiteService;
-    private final Consumer<String> onNavigate;
+    public interface HomeNavigation {
+        void navigateTo(String key);
+        void openInventarioBajoMinimo();
+        void openTramitesNuevos();
+        void openMovimientosHoy();
+    }
+
+    private final HomeNavigation navigation;
 
     // Labels de métricas (para refrescar)
-    private JLabel lblTareasPend;
-    private JLabel lblAprobPend;
     private JLabel lblInsumosCriticos;
-    private JLabel lblBalance;
+    private JLabel lblTramitesNuevos;
+    private JLabel lblSalidasHoy;
     private JLabel lblAlertStock;
 
     // Contenedor dinámico de la tarjeta de actividad
@@ -52,11 +57,11 @@ public class HomePage extends JPanel {
     public HomePage(Usuario usuarioActual,
                     InventarioService inventarioService,
                     TramiteService tramiteService,
-                    Consumer<String> onNavigate) {
+                    HomeNavigation navigation) {
         this.usuarioActual = usuarioActual;
         this.inventarioService = inventarioService;
         this.tramiteService = tramiteService;
-        this.onNavigate = onNavigate;
+        this.navigation = navigation;
 
         setOpaque(false);
         setLayout(new BorderLayout());
@@ -183,21 +188,19 @@ public class HomePage extends JPanel {
     }
 
     private JPanel metricsRow() {
-        JPanel row = new JPanel(new GridLayout(1, 4, 16, 0));
+        JPanel row = new JPanel(new GridLayout(1, 3, 16, 0));
         row.setOpaque(false);
 
-        row.add(metricCard("Tareas pendientes", lblTareasPend = new JLabel("0"),
-                "Trámites por resolver", new Color(58, 109, 255)));
-        row.add(metricCard("Aprob. pendientes", lblAprobPend = new JLabel("0"),
-                "Trámites en espera", new Color(86, 127, 255)));
-        row.add(metricCard("Insumos críticos", lblInsumosCriticos = new JLabel("0"),
-                "Stock bajo el mínimo", new Color(255, 99, 99)));
-        row.add(metricCard("Balance dpto", lblBalance = new JLabel("0 u."),
-                "Unidades disponibles", new Color(58, 182, 186)));
+        row.add(metricCard("Insumos bajo mínimo", lblInsumosCriticos = new JLabel("0"),
+                "Stock por reponer", new Color(255, 99, 99), this::openInventarioBajoMinimo));
+        row.add(metricCard("Trámites nuevos", lblTramitesNuevos = new JLabel("0"),
+                "Ingresados recientemente", new Color(86, 127, 255), this::openTramitesNuevos));
+        row.add(metricCard("Últimas salidas (hoy)", lblSalidasHoy = new JLabel("0"),
+                "Movimientos registrados hoy", new Color(58, 182, 186), this::openMovimientosHoy));
         return row;
     }
 
-    private JPanel metricCard(String title, JLabel valueLabel, String hint, Color base) {
+    private JPanel metricCard(String title, JLabel valueLabel, String hint, Color base, Runnable onClick) {
         JPanel card = new JPanel() {
             @Override
             protected void paintComponent(Graphics g) {
@@ -232,12 +235,7 @@ public class HomePage extends JPanel {
         card.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         card.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override public void mouseClicked(java.awt.event.MouseEvent e) {
-                switch (title.toLowerCase()) {
-                    case "insumos críticos" -> navigateOrInfo("inventario");
-                    case "aprob. pendientes" -> navigateOrInfo("tramites");
-                    case "tareas pendientes" -> navigateOrInfo("tramites");
-                    case "balance dpto"      -> navigateOrInfo("finanzas");
-                }
+                if (onClick != null) onClick.run();
             }
         });
         return card;
@@ -313,39 +311,22 @@ public class HomePage extends JPanel {
 
     /** Refresca las métricas del dashboard. */
     public void refreshMetrics() {
-        int tareasPendientes = 0;
-        int aprobPendientes = 0;
+        int criticos = 0;
+        int tramitesNuevos = 0;
+        int salidasHoy = 0;
 
         if (tramiteService != null) {
             try {
                 List<Tramite> tramites = tramiteService.listarTodos();
-                tareasPendientes = (int) tramites.stream()
+                tramitesNuevos = (int) tramites.stream()
                         .filter(t -> {
                             String estado = t.getEstado();
-                            if (estado == null) return true;
-                            String up = estado.trim().toUpperCase(Locale.ROOT);
-                            return !up.equals("COMPLETADO") && !up.equals("CERRADO");
-                        })
-                        .count();
-
-                aprobPendientes = (int) tramites.stream()
-                        .filter(t -> {
-                            String estado = t.getEstado();
-                            if (estado == null) return false;
-                            String up = estado.trim().toUpperCase(Locale.ROOT);
-                            return up.equals("PENDIENTE") || up.equals("NUEVO");
+                            return estado != null && "NUEVO".equalsIgnoreCase(estado.trim());
                         })
                         .count();
             } catch (Exception ignored) {
-                // mantenemos valores anteriores ante errores
             }
         }
-
-        lblTareasPend.setText(String.valueOf(tareasPendientes));
-        lblAprobPend.setText(String.valueOf(aprobPendientes));
-
-        int criticos = 0;
-        int totalStock = 0;
 
         if (inventarioService != null) {
             try {
@@ -353,30 +334,29 @@ public class HomePage extends JPanel {
                 for (Insumo i : insumos) {
                     Integer min = i.getStockMinimo();
                     Long id = i.getId();
-                    int actual = 0;
+                    BigDecimal actual = BigDecimal.ZERO;
                     if (id != null) {
                         try {
-                            //actual = inventarioService.stockActual(id);
-                            actual = inventarioService.stockActual(id.longValue());
+                            actual = inventarioService.stockActualExacto(id);
                         } catch (Exception ex) {
-                            actual = 0;
+                            actual = BigDecimal.ZERO;
                         }
                     }
-                    if (min != null && actual < min) {
+                    if (min != null && actual.compareTo(BigDecimal.valueOf(min)) < 0) {
                         criticos++;
                     }
-                    totalStock += Math.max(0, actual);
                 }
+                salidasHoy = inventarioService.movimientosPorFechaYTipo(java.time.LocalDate.now(),
+                        java.time.LocalDate.now(), "SALIDA").size();
             } catch (Exception ignored) {
                 // dejamos los valores previos si algo falla
             }
         }
 
         lblInsumosCriticos.setText(String.valueOf(criticos));
+        lblTramitesNuevos.setText(String.valueOf(tramitesNuevos));
+        lblSalidasHoy.setText(String.valueOf(salidasHoy));
         updateAlertStock(criticos);
-
-        NumberFormat nf = NumberFormat.getIntegerInstance(new Locale("es", "AR"));
-        lblBalance.setText(nf.format(totalStock) + " u.");
     }
 
     private void updateAlertStock(int criticos) {
@@ -430,8 +410,23 @@ public class HomePage extends JPanel {
 
 
     /** Navega usando el callback, o informa si no está configurado. */
+    private void openInventarioBajoMinimo() {
+        if (navigation != null) navigation.openInventarioBajoMinimo();
+        else navigateOrInfo("inventario");
+    }
+
+    private void openTramitesNuevos() {
+        if (navigation != null) navigation.openTramitesNuevos();
+        else navigateOrInfo("tramites");
+    }
+
+    private void openMovimientosHoy() {
+        if (navigation != null) navigation.openMovimientosHoy();
+        else navigateOrInfo("movimientos");
+    }
+
     private void navigateOrInfo(String pageKey) {
-        if (onNavigate != null) onNavigate.accept(pageKey);
+        if (navigation != null) navigation.navigateTo(pageKey);
         else JOptionPane.showMessageDialog(this,
                 "Navegación a: " + pageKey + " (configurá onNavigate en ShellFrame).",
                 "Navegación", JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
@@ -2,6 +2,7 @@ package ar.edu.unse.siga.ui.pages;
 
 import ar.edu.unse.siga.domain.Insumo;
 import ar.edu.unse.siga.domain.Movimiento;
+import ar.edu.unse.siga.domain.Ubicacion;
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.InventarioService.StockCheckResult;
 import ar.edu.unse.siga.ui.base.CardPanel;
@@ -10,8 +11,10 @@ import ar.edu.unse.siga.ui.inventario.MovimientoDialog;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class InventoryMovementsPage extends JPanel {
 
@@ -28,7 +31,7 @@ public class InventoryMovementsPage extends JPanel {
     private final DefaultListModel<String> historialModel = new DefaultListModel<>();
     private final JList<String> lstHistorial = new JList<>(historialModel);
     
-    public void refreshInsumos() { /* repoblar la lista desde DAO/Service */ }
+    public void refreshInsumos() { loadInsumos(""); }
 
 
     public InventoryMovementsPage(InventarioService service) {
@@ -142,7 +145,14 @@ public class InventoryMovementsPage extends JPanel {
                 if (selected != null) {
                     refreshSelectedSummary();
                     refreshHistorial(selected.getId());
-                    setActionsEnabled(true);
+                    boolean activo = selected.getEstado() == null
+                            || !"INACTIVO".equalsIgnoreCase(selected.getEstado());
+                    setActionsEnabled(activo);
+                    if (!activo) {
+                        JOptionPane.showMessageDialog(InventoryMovementsPage.this,
+                                "El insumo está INACTIVO; no se pueden registrar movimientos.",
+                                "Atención", JOptionPane.WARNING_MESSAGE);
+                    }
                 } else {
                     setActionsEnabled(false);
                     taSeleccion.setText("Seleccioná un insumo");
@@ -216,6 +226,7 @@ public class InventoryMovementsPage extends JPanel {
     private void stylePrimary(JButton b) {
         b.setFocusPainted(false);
         b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        b.setPreferredSize(new Dimension(170, 38));
     }
 
     private void setActionsEnabled(boolean enabled) {
@@ -246,69 +257,69 @@ public class InventoryMovementsPage extends JPanel {
             JOptionPane.showMessageDialog(this, "Seleccioná un insumo primero.", "Atención", JOptionPane.WARNING_MESSAGE);
             return;
         }
+        if (sel.getEstado() != null && "INACTIVO".equalsIgnoreCase(sel.getEstado())) {
+            JOptionPane.showMessageDialog(this, "El insumo está INACTIVO; no se pueden registrar movimientos.",
+                    "Atención", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
 
-        int stock = 0;
+        BigDecimal stockActual = BigDecimal.ZERO;
         try {
             StockCheckResult res = service.stockActual(sel.getId());
-            stock = (res != null && res.stockActual != null) ? res.stockActual : 0;   // ← usar lo devuelto
+            stockActual = res == null ? BigDecimal.ZERO : res.getStockActualDecimal();
         } catch (Exception ignored) {}
 
         var win = SwingUtilities.getWindowAncestor(this);
-        String ctx = "Insumo: " + sel.getCodigo() + " · " + sel.getDescripcion()
-                + "  |  Stock actual: " + stock;
+        String ctx = String.format("Insumo: %s · %s  |  Stock actual: %s",
+                sel.getCodigo(),
+                sel.getDescripcion() == null ? "" : sel.getDescripcion(),
+                formatCantidad(stockActual));
 
-        MovimientoDialog dlg = new MovimientoDialog(win, ctx, tipoInicial, null, 1);
+        boolean allowDecimal = sel.getTipo() == null || !"BIEN".equalsIgnoreCase(sel.getTipo());
+        List<String> ubicaciones = service.listarUbicaciones().stream()
+                .map(Ubicacion::getNombre)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toList());
+
+        MovimientoDialog dlg = new MovimientoDialog(win, ctx, tipoInicial, allowDecimal, ubicaciones);
         dlg.setVisible(true);
         if (!dlg.isAccepted()) return;
 
-        String tipo = dlg.getTipo();
-        int cantidad = dlg.getCantidad();
+        BigDecimal cantidad = dlg.getCantidad();
         String destino = dlg.getDestinoFuente();
 
-        if (cantidad <= 0) {
+        if (cantidad.compareTo(BigDecimal.ZERO) <= 0) {
             JOptionPane.showMessageDialog(this, "La cantidad debe ser mayor a 0.", "Atención", JOptionPane.WARNING_MESSAGE);
             return;
         }
 
-        // Pre-chequeo SALIDA
         try {
-            StockCheckResult res = service.stockActual(sel.getId());
-            stock = (res != null && res.stockActual != null) ? res.stockActual : 0;   // ← actualizar base para validar
-        } catch (Exception ignored) {}
-        if ("SALIDA".equalsIgnoreCase(tipo) && cantidad > stock) {
-            JOptionPane.showMessageDialog(this,
-                    String.format("No hay suficiente stock para realizar esta salida.\n\nCantidad disponible: %d\nCantidad solicitada: %d\n\nPodés registrar una cantidad menor o agregar más stock con una ENTRADA.",
-                            stock, cantidad),
-                    "Error", JOptionPane.ERROR_MESSAGE);
-            return;
-        }
+            service.registrarMovimiento(sel.getId(), tipoInicial, cantidad, destino);
 
-        try {
-            // *** REGISTRAR MOVIMIENTO EN BD ***
-            service.registrarMovimiento(sel.getId(), tipo, cantidad, destino);
-
-            // Consultar stock actualizado y notificar
             StockCheckResult res = service.stockActual(sel.getId());
+            BigDecimal nuevoStock = res == null ? BigDecimal.ZERO : res.getStockActualDecimal();
 
             JOptionPane.showMessageDialog(this,
-                    String.format("%s registrada.\nStock actual: %d",
-                            tipo, (res.stockActual == null ? 0 : res.stockActual)),
+                    String.format("%s registrada.\nStock actual: %s",
+                            tipoInicial, formatCantidad(nuevoStock)),
                     "OK", JOptionPane.INFORMATION_MESSAGE);
 
-            if (res.bajoMinimo) {
+            if (res != null && res.isBajoMinimo()) {
                 JOptionPane.showMessageDialog(this,
-                        String.format("⚠ Stock por debajo del mínimo.\nActual: %d  |  Mínimo: %s",
-                                (res.stockActual == null ? 0 : res.stockActual),
-                                res.stockMinimo == null ? "-" : res.stockMinimo),
+                        String.format("⚠ Stock por debajo del mínimo.\nActual: %s  |  Mínimo: %s",
+                                formatCantidad(nuevoStock),
+                                res.getStockMinimo() == null ? "-" : res.getStockMinimo()),
                         "Alerta de reposición", JOptionPane.WARNING_MESSAGE);
             }
 
             refreshHistorial(sel.getId());
             refreshSelectedSummary();
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Atención", JOptionPane.WARNING_MESSAGE);
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(this, "Ocurrió un error al registrar el movimiento.",
+            JOptionPane.showMessageDialog(this,
+                    "Ocurrió un error al registrar el movimiento.\n" + ex.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
-            ex.printStackTrace();
         }
     }
 
@@ -320,8 +331,9 @@ public class InventoryMovementsPage extends JPanel {
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
             for (Movimiento m : movs) {
                 String fecha = (m.getFecha() != null ? m.getFecha().format(fmt) : "");
-                String linea = String.format("%s · x%d %s · Destino: %s",
-                        fecha, m.getCantidad(), m.getTipo(),
+                String cantidad = formatCantidad(m.getCantidad());
+                String linea = String.format("%s · x%s %s · Destino: %s",
+                        fecha, cantidad, m.getTipo(),
                         (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank()) ? "-" : m.getDestinoFuente());
                 historialModel.addElement(linea);
             }
@@ -337,26 +349,36 @@ public class InventoryMovementsPage extends JPanel {
             if (resumenColorNormal != null) taSeleccion.setForeground(resumenColorNormal);
             return;
         }
-        int stockAct = 0;
+        BigDecimal stockAct = BigDecimal.ZERO;
         try {
             StockCheckResult res = service.stockActual(sel.getId());
-            stockAct = (res != null && res.stockActual != null) ? res.stockActual : 0; // ← usar lo devuelto
+            stockAct = (res != null) ? res.getStockActualDecimal() : BigDecimal.ZERO;
         } catch (Exception ignored) {}
 
         String cod = sel.getCodigo() == null ? "-" : sel.getCodigo();
         String desc = sel.getDescripcion() == null ? "-" : sel.getDescripcion();
         String min = sel.getStockMinimo() == null ? "-" : String.valueOf(sel.getStockMinimo());
 
-        taSeleccion.setText(String.format("#%d · %s · %s%nStock mín.: %s  |  Stock actual: %d",
-                sel.getId(), cod, desc, min, stockAct));
+        String tipo = sel.getTipo() == null ? "INSUMO" : sel.getTipo();
+        String estado = sel.getEstado() == null ? "ACTIVO" : sel.getEstado();
+
+        taSeleccion.setText(String.format("#%d · %s · %s (%s)%nEstado: %s%nStock mín.: %s  |  Stock actual: %s",
+                sel.getId(), cod, desc, tipo, estado,
+                min, formatCantidad(stockAct)));
         taSeleccion.setCaretPosition(0);
         taSeleccion.setToolTipText(desc.length() > 40 ? desc : null);
 
-        boolean bajoMinimo = (sel.getStockMinimo() != null) && (stockAct < sel.getStockMinimo());
+        boolean bajoMinimo = sel.getStockMinimo() != null
+                && stockAct.compareTo(BigDecimal.valueOf(sel.getStockMinimo())) < 0;
         if (bajoMinimo) {
             taSeleccion.setForeground(new Color(176, 0, 32));
         } else if (resumenColorNormal != null) {
             taSeleccion.setForeground(resumenColorNormal);
         }
+    }
+
+    private String formatCantidad(BigDecimal valor) {
+        if (valor == null) return "0";
+        return valor.stripTrailingZeros().toPlainString();
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
@@ -1,36 +1,39 @@
 package ar.edu.unse.siga.ui.pages;
 
+import ar.edu.unse.siga.common.CurrentSession;
+import ar.edu.unse.siga.domain.Categoria;
+import ar.edu.unse.siga.domain.Insumo;
+import ar.edu.unse.siga.domain.Ubicacion;
+import ar.edu.unse.siga.domain.Usuario;
 import ar.edu.unse.siga.service.InventarioService;
-import ar.edu.unse.siga.service.InventarioService.StockCheckResult;
 import ar.edu.unse.siga.ui.base.CardPanel;
+import ar.edu.unse.siga.ui.base.Ui;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import java.awt.*;
-
-import ar.edu.unse.siga.domain.Insumo;
-import ar.edu.unse.siga.domain.Categoria;
-import ar.edu.unse.siga.persistence.jdbc.JdbcInsumoDao;
-import ar.edu.unse.siga.persistence.jdbc.JdbcCategoriaDao;
-import ar.edu.unse.siga.ui.base.Ui;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.JComboBox;
-import javax.swing.ComboBoxModel;
-
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 public class InventoryPage extends JPanel {
-    
-    private JComboBox<String> cbUbicacionDelete = buildUbicacionCombo();
 
+    private static final Dimension BUTTON_SIZE = new Dimension(180, 42);
 
-    private final InventarioService service;   // <--- se inyecta desde ShellFrame
+    private final InventarioService service;
     private final CardLayout cardLayout = new CardLayout();
     private final JPanel cards = new JPanel(cardLayout);
-    // Reemplazá el JTextField existente:
-// private JTextField txtUbicacion;
+    private JToggleButton tabRegistrar;
+    private JToggleButton tabModificar;
+    private JToggleButton tabEliminar;
 
-private JComboBox<String> cbUbicacionEdit = buildUbicacionCombo();
-
-    
+    private final RegistroPanel registroPanel = new RegistroPanel();
+    private final ModificarPanel modificarPanel = new ModificarPanel();
+    private final EliminarPanel eliminarPanel = new EliminarPanel();
 
     public InventoryPage(InventarioService service) {
         this.service = service;
@@ -38,721 +41,75 @@ private JComboBox<String> cbUbicacionEdit = buildUbicacionCombo();
         setLayout(new BorderLayout(16, 16));
 
         add(buildHeader(), BorderLayout.NORTH);
-        add(buildCardHolder(), BorderLayout.CENTER);
+        add(buildContent(), BorderLayout.CENTER);
     }
-    
-    // === Opciones fijas de ubicación (podés cambiar el orden si querés) ===
-private static final String[] UBICACIONES_FIJAS = {
-            "Sede Central",
-            "Sede Zanjon",
-            "Sede Parque Industrial",
-};
-
-// Crea el combo ya estilizado
-private static JComboBox<String> buildUbicacionCombo() {
-    JComboBox<String> cb = new JComboBox<>(UBICACIONES_FIJAS);
-    cb.putClientProperty("JComponent.roundRect", true);
-    return cb;
-}
-
-// Selecciona el valor existente del insumo; si no está en la lista, lo agrega al combo y lo selecciona
-private static void selectOrAdd(JComboBox<String> cb, String ubic) {
-    if (ubic == null || ubic.isBlank()) return;
-    ComboBoxModel<String> m = cb.getModel();
-    boolean exists = false;
-    for (int i = 0; i < m.getSize(); i++) {
-        if (ubic.equalsIgnoreCase(m.getElementAt(i))) { exists = true; break; }
-    }
-    if (!exists) cb.addItem(ubic);
-    cb.setSelectedItem(ubic);
-}
-
 
     private JComponent buildHeader() {
         JPanel header = new JPanel(new BorderLayout(12, 12));
         header.setOpaque(false);
 
         JLabel title = new JLabel("Gestión de inventario");
-        title.setForeground(new Color(24, 63, 150));
         title.setFont(title.getFont().deriveFont(Font.BOLD, 28f));
+        title.setForeground(new Color(24, 63, 150));
         header.add(title, BorderLayout.WEST);
 
         return header;
     }
 
-    private JComponent buildCardHolder() {
+    private JComponent buildContent() {
         JPanel wrapper = new JPanel(new BorderLayout(16, 24));
         wrapper.setOpaque(false);
 
         ButtonGroup group = new ButtonGroup();
-        var bar = new JPanel(new FlowLayout(FlowLayout.LEFT, 12, 0));
-        bar.setOpaque(false);
+        JPanel tabs = new JPanel(new FlowLayout(FlowLayout.LEFT, 12, 0));
+        tabs.setOpaque(false);
 
-        JToggleButton btnRegistrar = pillButton("Cargar");
-        JToggleButton btnModificar = pillButton("Modificar");
-        JToggleButton btnEliminar = pillButton("Eliminar");
-        //JToggleButton btnMovimiento = pillButton("Registrar movimiento");
+        tabRegistrar = pillButton("Cargar");
+        tabModificar = pillButton("Modificar");
+        tabEliminar = pillButton("Eliminar");
 
-        group.add(btnRegistrar);
-        group.add(btnModificar);
-        group.add(btnEliminar);
-        //group.add(btnMovimiento);
-        btnRegistrar.setSelected(true);
+        tabRegistrar.setSelected(true);
+        group.add(tabRegistrar);
+        group.add(tabModificar);
+        group.add(tabEliminar);
 
-        bar.add(btnRegistrar);
-        bar.add(btnModificar);
-        bar.add(btnEliminar);
-        //bar.add(btnMovimiento);
+        tabs.add(tabRegistrar);
+        tabs.add(tabModificar);
+        tabs.add(tabEliminar);
 
-        wrapper.add(bar, BorderLayout.NORTH);
+        wrapper.add(tabs, BorderLayout.NORTH);
 
         cards.setOpaque(false);
-        cards.add(buildRegistroCard(), "reg");
-        cards.add(buildModificarCard(), "mod");
-        cards.add(buildEliminarCard(), "del");
-        //cards.add(buildMovimientoCard(), "mov");
-
-        btnRegistrar.addActionListener(e -> cardLayout.show(cards, "reg"));
-        btnModificar.addActionListener(e -> cardLayout.show(cards, "mod"));
-        btnEliminar.addActionListener(e -> cardLayout.show(cards, "del"));
-        //btnMovimiento.addActionListener(e -> cardLayout.show(cards, "mov"));
-
+        cards.add(registroPanel, "reg");
+        cards.add(modificarPanel, "mod");
+        cards.add(eliminarPanel, "del");
         wrapper.add(cards, BorderLayout.CENTER);
-        cardLayout.show(cards, "reg");
 
+        tabRegistrar.addActionListener(e -> {
+            registroPanel.refreshCombos();
+            cardLayout.show(cards, "reg");
+        });
+        tabModificar.addActionListener(e -> {
+            modificarPanel.refreshData();
+            cardLayout.show(cards, "mod");
+        });
+        tabEliminar.addActionListener(e -> {
+            eliminarPanel.refreshData();
+            cardLayout.show(cards, "del");
+        });
+
+        cardLayout.show(cards, "reg");
         return wrapper;
     }
 
-    private CardPanel buildRegistroCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 16));
-
-        JLabel lbl = new JLabel("REGISTRO DE INVENTARIO");
-        lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 16f));
-        lbl.setForeground(new Color(70, 96, 180));
-        card.add(lbl, BorderLayout.NORTH);
-
-        // --- Campos
-        JTextField txtCodigo = new JTextField();
-        txtCodigo.putClientProperty("JTextField.placeholderText", "Ej: INS001");
-        txtCodigo.putClientProperty("JComponent.roundRect", true);
-
-        JTextField txtDescripcion = new JTextField();
-        txtDescripcion.putClientProperty("JTextField.placeholderText", "Descripción...");
-        txtDescripcion.putClientProperty("JComponent.roundRect", true);
-
-        // CATEGORÍA COMO COMBO (llenado desde BD)
-        var catDao = new JdbcCategoriaDao();
-        var categorias = catDao.listAll();
-        JComboBox<Categoria> cbCategoria = new JComboBox<>(categorias.toArray(new Categoria[0]));
-        cbCategoria.putClientProperty("JComponent.roundRect", true);
-        if (cbCategoria.getItemCount() > 0) {
-            cbCategoria.setSelectedIndex(0);
-        }
-
-        // Ubicación
-        // UBICACIÓN COMO COMBO (opciones fijas)
-        String[] ubicaciones = new String[] {
-            "Sede Central",
-            "Sede Zanjon",
-            "Sede Parque Industrial",
-        };
-
-        JComboBox<String> cbUbicacion = new JComboBox<>(ubicaciones);
-        cbUbicacion.putClientProperty("JComponent.roundRect", true);
-        if (cbUbicacion.getItemCount() > 0) {
-            cbUbicacion.setSelectedIndex(0);
-        }
-
-
-        // Stock mínimo
-        JSpinner spStockMin = new JSpinner(new SpinnerNumberModel(0, 0, 999999, 1));
-        tuneNumericSpinner(spStockMin, 0, 999999);
-        
-        JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
-        form.setOpaque(false);
-        form.add(labeled("CÓDIGO", txtCodigo));
-        form.add(labeled("DESCRIPCIÓN", txtDescripcion));
-        form.add(labeled("CATEGORÍA", cbCategoria));
-        form.add(labeled("UBICACIÓN", cbUbicacion));
-        form.add(labeled("STOCK MÍNIMO", spStockMin));
-        card.add(form, BorderLayout.CENTER);
-
-        // --- Botón Aceptar
-        JButton btn = new JButton("Aceptar");
-        btn.setPreferredSize(new Dimension(160, 40));
-        btn.setBackground(new Color(58, 96, 224));
-        btn.setForeground(Color.WHITE);
-        btn.setFocusPainted(false);
-
-        btn.addActionListener(e -> {
-            try {
-                String codigo = txtCodigo.getText().trim();
-                String desc = txtDescripcion.getText().trim();
-                Categoria cat = (Categoria) cbCategoria.getSelectedItem();
-                String ubic = java.util.Objects.toString(cbUbicacion.getSelectedItem(), "").trim();
-
-
-                Object v = spStockMin.getValue();
-                if (!(v instanceof Number)) {
-                    Ui.warn(this, "El stock mínimo debe ser numérico.");
-                    return;
-                }
-                int stockMin = ((Number) v).intValue();
-
-                if (codigo.isEmpty() || desc.isEmpty()) {
-                    throw new IllegalArgumentException("Código y descripción son obligatorios.");
-                }
-                if (cat == null) {
-                    throw new IllegalArgumentException("Seleccioná una categoría.");
-                }
-
-                Insumo ins = new Insumo();
-                ins.setCodigo(codigo);
-                ins.setDescripcion(desc);
-                ins.setCategoria(cat);
-                ins.setUbicacion(ubic);
-                ins.setStockMinimo(stockMin);
-                ins.setEstado("ACTIVO");
-
-                Long id = new JdbcInsumoDao().create(ins);
-                Ui.info(this, "Insumo guardado. ID = " + id);
-
-                // limpiar
-                txtCodigo.setText("");
-                txtDescripcion.setText("");
-                if (cbCategoria.getItemCount() > 0) {
-                    cbCategoria.setSelectedIndex(0);
-                }
-                cbUbicacion.setSelectedIndex(0); // o cbUbicacion.setSelectedItem("Facultad de Ciencias Exactas");
-
-                spStockMin.setValue(0);
-            } catch (Exception ex) {
-                Ui.error(this, ex);
+    public void mostrarInsumosBajoMinimo() {
+        SwingUtilities.invokeLater(() -> {
+            if (tabModificar != null) {
+                tabModificar.setSelected(true);
             }
+            cardLayout.show(cards, "mod");
+            modificarPanel.mostrarSoloBajoMinimo();
         });
-
-        JPanel south = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        south.setOpaque(false);
-        south.add(btn);
-        card.add(south, BorderLayout.SOUTH);
-
-        return card;
-    }
-
-    // Helper para spinners numéricos
-    private static void tuneNumericSpinner(JSpinner spinner, int min, int max) {
-        if (!(spinner.getModel() instanceof SpinnerNumberModel)) {
-            spinner.setModel(new SpinnerNumberModel(0, min, max, 1));
-        }
-        JSpinner.NumberEditor editor = new JSpinner.NumberEditor(spinner, "#");
-        spinner.setEditor(editor);
-        JFormattedTextField tf = editor.getTextField();
-        if (tf.getFormatter() instanceof javax.swing.text.NumberFormatter nf) {
-            nf.setAllowsInvalid(false);
-            nf.setCommitsOnValidEdit(true);
-            nf.setMinimum(min);
-            nf.setMaximum(max);
-        }
-    }
-
-    private CardPanel buildEliminarCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 16));
-
-        JLabel lbl = new JLabel("ELIMINACIÓN DE INVENTARIO");
-        lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 16f));
-        lbl.setForeground(new Color(180, 70, 70));
-        card.add(lbl, BorderLayout.NORTH);
-
-        // ---- Búsqueda por código
-        JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
-        top.setOpaque(false);
-        JTextField txtBuscarCodigo = new JTextField(18);
-        txtBuscarCodigo.putClientProperty("JTextField.placeholderText", "Código a buscar (ej: INS001)");
-        JButton btnBuscar = new JButton("Buscar");
-        top.add(new JLabel("Código:"));
-        top.add(txtBuscarCodigo);
-        top.add(btnBuscar);
-        card.add(top, BorderLayout.PAGE_START);
-
-        // ---- Campos solo lectura
-        JTextField txtCodigo = new JTextField();
-        txtCodigo.setEditable(false);
-        JTextField txtDescripcion = new JTextField();
-        txtDescripcion.setEditable(false);
-        JComboBox<Categoria> cbCategoria = new JComboBox<>();
-        cbCategoria.setEnabled(false);
-        JTextField txtUbicacion = new JTextField();
-        txtUbicacion.setEditable(false);
-        JSpinner spStockMin = new JSpinner(new SpinnerNumberModel(0, 0, 999999, 1));
-        spStockMin.setEnabled(false);
-        JComboBox<String> cbEstado = new JComboBox<>(new String[]{"ACTIVO", "INACTIVO"});
-        cbEstado.setEnabled(false);
-
-        for (Categoria c : new JdbcCategoriaDao().listAll()) {
-            cbCategoria.addItem(c);
-        }
-        if (cbCategoria.getItemCount() > 0) {
-            cbCategoria.setSelectedIndex(0);
-        }
-
-        JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
-        form.setOpaque(false);
-        form.add(labeled("CÓDIGO", txtCodigo));
-        form.add(labeled("DESCRIPCIÓN", txtDescripcion));
-        form.add(labeled("CATEGORÍA", cbCategoria));
-        form.add(labeled("UBICACIÓN", cbUbicacionDelete));
-        form.add(labeled("STOCK MÍNIMO", spStockMin));
-        form.add(labeled("ESTADO", cbEstado));
-        card.add(form, BorderLayout.CENTER);
-
-        final Insumo[] current = new Insumo[1];
-
-        final JButton btnEliminar = new JButton("Eliminar");
-        btnEliminar.setPreferredSize(new Dimension(140, 40));
-        btnEliminar.setBackground(new Color(200, 60, 60));
-        btnEliminar.setForeground(Color.WHITE);
-        btnEliminar.setFocusPainted(false);
-        btnEliminar.setEnabled(false);
-
-        btnBuscar.addActionListener(e -> {
-            try {
-                btnEliminar.setEnabled(false);
-                String codigo = txtBuscarCodigo.getText().trim();
-                if (codigo.isEmpty()) {
-                    Ui.warn(InventoryPage.this, "Ingresá un código para buscar.");
-                    return;
-                }
-                var dao = new JdbcInsumoDao();
-                var opt = dao.findByCodigo(codigo);
-                if (opt.isEmpty()) {
-                    Ui.warn(InventoryPage.this, "No se encontró un insumo con código: " + codigo);
-                    current[0] = null;
-                    txtCodigo.setText("");
-                    txtDescripcion.setText("");
-                    txtUbicacion.setText("");
-                    spStockMin.setValue(0);
-                    if (cbCategoria.getItemCount() > 0) {
-                        cbCategoria.setSelectedIndex(0);
-                    }
-                    cbEstado.setSelectedIndex(0);
-                    return;
-                }
-
-                current[0] = opt.get();
-                String estado = current[0].getEstado() == null ? "ACTIVO" : current[0].getEstado();
-
-                if (!"ACTIVO".equalsIgnoreCase(estado)) {
-                    Ui.warn(InventoryPage.this, "El insumo " + codigo + " ya está INACTIVO; no se puede dar de baja.");
-                    current[0] = null;
-                    txtCodigo.setText("");
-                    txtDescripcion.setText("");
-                    txtUbicacion.setText("");
-                    spStockMin.setValue(0);
-                    if (cbCategoria.getItemCount() > 0) {
-                        cbCategoria.setSelectedIndex(0);
-                    }
-                    cbEstado.setSelectedIndex(1);
-                    return;
-                }
-
-                txtCodigo.setText(current[0].getCodigo());
-                txtDescripcion.setText(current[0].getDescripcion() == null ? "" : current[0].getDescripcion());
-                txtUbicacion.setText(current[0].getUbicacion() == null ? "" : current[0].getUbicacion());
-                Integer sm = current[0].getStockMinimo();
-                spStockMin.setValue(sm == null ? 0 : sm);
-
-                var cat = current[0].getCategoria();
-                if (cat != null) {
-                    for (int i = 0; i < cbCategoria.getItemCount(); i++) {
-                        if (cbCategoria.getItemAt(i).getId() == cat.getId()) {
-                            cbCategoria.setSelectedIndex(i);
-                            break;
-                        }
-                    }
-                }
-                cbEstado.setSelectedItem(estado);
-                btnEliminar.setEnabled(true);
-            } catch (Exception ex) {
-                Ui.error(InventoryPage.this, ex);
-            }
-        });
-
-        btnEliminar.addActionListener(e -> {
-            try {
-                if (current[0] == null) {
-                    Ui.warn(InventoryPage.this, "Primero buscá un insumo por código.");
-                    return;
-                }
-                String estado = current[0].getEstado() == null ? "ACTIVO" : current[0].getEstado();
-                if (!"ACTIVO".equalsIgnoreCase(estado)) {
-                    Ui.warn(InventoryPage.this, "El insumo ya está INACTIVO.");
-                    return;
-                }
-                String cod = current[0].getCodigo();
-                if (!Ui.confirm(InventoryPage.this, "¿Confirmás la eliminación (baja) de " + cod + "?")) {
-                    return;
-                }
-                new JdbcInsumoDao().softDelete(current[0].getId());
-                Ui.info(InventoryPage.this, "El insumo " + cod + " fue dado de baja (INACTIVO).");
-
-                current[0] = null;
-                txtCodigo.setText("");
-                txtDescripcion.setText("");
-                txtUbicacion.setText("");
-                spStockMin.setValue(0);
-                if (cbCategoria.getItemCount() > 0) {
-                    cbCategoria.setSelectedIndex(0);
-                }
-                cbEstado.setSelectedIndex(0);
-                txtBuscarCodigo.setText("");
-                btnEliminar.setEnabled(false);
-            } catch (Exception ex) {
-                Ui.error(InventoryPage.this, ex);
-            }
-        });
-
-        JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        south.setOpaque(false);
-        south.add(btnEliminar);
-        card.add(south, BorderLayout.SOUTH);
-
-        return card;
-    }
-
-    private CardPanel buildMovimientoCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 16));
-
-        JLabel lbl = new JLabel("REGISTRO DE MOVIMIENTO");
-        lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 16f));
-        lbl.setForeground(new Color(70, 96, 180));
-        card.add(lbl, BorderLayout.NORTH);
-
-        // --- Campos
-        JComboBox<Insumo> cbInsumo = new JComboBox<>();
-        for (Insumo i : service.listarTodos()) {
-            cbInsumo.addItem(i);
-        }
-        if (cbInsumo.getItemCount() > 0) {
-            cbInsumo.setSelectedIndex(0);
-        }
-
-        JComboBox<String> cbTipo = new JComboBox<>(new String[]{"ENTRADA", "SALIDA"});
-
-        JSpinner spCantidad = new JSpinner(new SpinnerNumberModel(1, 1, 999999, 1));
-        tuneNumericSpinner(spCantidad, 1, 999999);
-
-        JTextField txtDestinoFuente = new JTextField(); // destino (salida) / fuente (entrada)
-
-        JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
-        form.setOpaque(false);
-        form.add(labeled("INSUMO", cbInsumo));
-        form.add(labeled("TIPO", cbTipo));
-        form.add(labeled("CANTIDAD", spCantidad));
-        form.add(labeled("DESTINO / FUENTE", txtDestinoFuente));
-        card.add(form, BorderLayout.CENTER);
-
-        JButton btnRegistrar = new JButton("Registrar");
-        btnRegistrar.setPreferredSize(new Dimension(140, 40));
-        btnRegistrar.setBackground(new Color(58, 96, 224));
-        btnRegistrar.setForeground(Color.WHITE);
-        btnRegistrar.setFocusPainted(false);
-
-        btnRegistrar.addActionListener(e -> {
-            try {
-                if (cbInsumo.getSelectedItem() == null) {
-                    Ui.warn(InventoryPage.this, "No hay insumos para registrar.");
-                    return;
-                }
-                Insumo insumo = (Insumo) cbInsumo.getSelectedItem();
-                String tipo = (String) cbTipo.getSelectedItem();
-
-                try {
-                    spCantidad.commitEdit();
-                } catch (java.text.ParseException ignore) {
-                }
-                Object vc = spCantidad.getValue();
-                if (!(vc instanceof Number)) {
-                    Ui.warn(InventoryPage.this, "La cantidad debe ser numérica.");
-                    return;
-                }
-                int cantidad = ((Number) vc).intValue();
-                if (cantidad <= 0) {
-                    Ui.warn(InventoryPage.this, "La cantidad debe ser mayor que cero.");
-                    return;
-                }
-
-                String destinoFuente = txtDestinoFuente.getText().trim();
-                if (destinoFuente.isEmpty()) {
-                    Ui.warn(InventoryPage.this, "Indicá el destino (salida) o la fuente (entrada).");
-                    return;
-                }
-
-                // Pre-chequeo para SALIDA con stock insuficiente
-                int stockActual = 0;
-                try {
-                    InventarioService.StockCheckResult res = service.stockActual(insumo.getId());
-
-                } catch (Exception ignored) {
-                }
-                if ("SALIDA".equalsIgnoreCase(tipo) && cantidad > stockActual) {
-                    JOptionPane.showMessageDialog(
-                            InventoryPage.this,
-                            "No hay suficiente stock para esta salida.\n"
-                            + "Disponible: " + stockActual + " | Solicitado: " + cantidad,
-                            "Error",
-                            JOptionPane.ERROR_MESSAGE
-                    );
-                    return;
-                }
-
-                // ✅ NUEVO: usar StockCheckResult (no devuelve Long)
-                InventarioService.StockCheckResult res = service.stockActual(insumo.getId());
-                Ui.info(InventoryPage.this,
-                        String.format("Movimiento registrado.\nStock actual: %d", res.stockActual));
-
-                if (res.bajoMinimo) {
-                    JOptionPane.showMessageDialog(InventoryPage.this,
-                            String.format("⚠ Stock por debajo del mínimo.\nActual: %d  |  Mínimo: %s",
-                                    res.stockActual,
-                                    res.stockMinimo == null ? "-" : res.stockMinimo),
-                            "Alerta de reposición", JOptionPane.WARNING_MESSAGE);
-                }
-
-                // Limpiar
-                cbTipo.setSelectedIndex(0);
-                spCantidad.setValue(1);
-                txtDestinoFuente.setText("");
-            } catch (Exception ex) {
-                Ui.error(InventoryPage.this, ex);
-            }
-        });
-
-        JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        south.setOpaque(false);
-        south.add(btnRegistrar);
-        card.add(south, BorderLayout.SOUTH);
-
-        return card;
-    }
-
-    private CardPanel buildModificarCard() {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 16));
-
-        JLabel lbl = new JLabel("MODIFICACIÓN DE INVENTARIO");
-        lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 16f));
-        lbl.setForeground(new Color(70, 96, 180));
-        card.add(lbl, BorderLayout.NORTH);
-
-        // ---- Búsqueda por código
-        JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
-        top.setOpaque(false);
-        JTextField txtBuscarCodigo = new JTextField(18);
-        txtBuscarCodigo.putClientProperty("JTextField.placeholderText", "Código a buscar (ej: INS001)");
-        JButton btnBuscar = new JButton("Buscar");
-        top.add(new JLabel("Código:"));
-        top.add(txtBuscarCodigo);
-        top.add(btnBuscar);
-        card.add(top, BorderLayout.PAGE_START);
-
-        // ---- Campos editables
-        JTextField txtCodigo = new JTextField();
-        txtCodigo.setEditable(false);
-        JTextField txtDescripcion = new JTextField();
-
-        JComboBox<Categoria> cbCategoria = new JComboBox<>();
-        for (Categoria c : new JdbcCategoriaDao().listAll()) {
-            cbCategoria.addItem(c);
-        }
-        if (cbCategoria.getItemCount() > 0) {
-            cbCategoria.setSelectedIndex(0);
-        }
-
-        JTextField txtUbicacion = new JTextField();
-        JSpinner spStockMin = new JSpinner(new SpinnerNumberModel(0, 0, 999999, 1));
-        tuneNumericSpinner(spStockMin, 0, 999999);
-
-        JComboBox<String> cbEstado = new JComboBox<>(new String[]{"ACTIVO", "INACTIVO"});
-
-        JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
-        form.setOpaque(false);
-        form.add(labeled("CÓDIGO", txtCodigo));
-        form.add(labeled("DESCRIPCIÓN", txtDescripcion));
-        form.add(labeled("CATEGORÍA", cbCategoria));
-        // Ubicación (AHORA, como combo)
-form.add(labeled("UBICACIÓN", cbUbicacionEdit));
-
-        form.add(labeled("STOCK MÍNIMO", spStockMin));
-        form.add(labeled("ESTADO", cbEstado));
-        card.add(form, BorderLayout.CENTER);
-
-        final Insumo[] current = new Insumo[1];
-
-        btnBuscar.addActionListener(e -> {
-            try {
-                String codigo = txtBuscarCodigo.getText().trim();
-                if (codigo.isEmpty()) {
-                    Ui.warn(InventoryPage.this, "Ingresá un código para buscar.");
-                    return;
-                }
-                var dao = new JdbcInsumoDao();
-                var opt = dao.findByCodigo(codigo);
-                if (opt.isEmpty()) {
-                    Ui.warn(InventoryPage.this, "No se encontró un insumo con código: " + codigo);
-                    // limpiar
-                    current[0] = null;
-                    txtCodigo.setText("");
-                    txtDescripcion.setText("");
-                    txtUbicacion.setText("");
-                    spStockMin.setValue(0);
-                    if (cbCategoria.getItemCount() > 0) {
-                        cbCategoria.setSelectedIndex(0);
-                    }
-                    cbEstado.setSelectedIndex(0);
-                    return;
-                }
-                // cargar datos
-                current[0] = opt.get();
-                txtCodigo.setText(current[0].getCodigo());
-                txtDescripcion.setText(current[0].getDescripcion() == null ? "" : current[0].getDescripcion());
-                txtUbicacion.setText(current[0].getUbicacion() == null ? "" : current[0].getUbicacion());
-
-                Integer sm = current[0].getStockMinimo();
-                spStockMin.setValue(sm == null ? 0 : sm);
-
-                var cat = current[0].getCategoria();
-                if (cat != null) {
-                    for (int i = 0; i < cbCategoria.getItemCount(); i++) {
-                        if (cbCategoria.getItemAt(i).getId() == cat.getId()) {
-                            cbCategoria.setSelectedIndex(i);
-                            break;
-                        }
-                    }
-                }
-                cbEstado.setSelectedItem(current[0].getEstado() == null ? "ACTIVO" : current[0].getEstado());
-            } catch (Exception ex) {
-                Ui.error(InventoryPage.this, ex);
-            }
-        });
-
-        JButton btnGuardar = new JButton("Guardar cambios");
-        btnGuardar.setPreferredSize(new Dimension(180, 40));
-        btnGuardar.setBackground(new Color(58, 96, 224));
-        btnGuardar.setForeground(Color.WHITE);
-        btnGuardar.setFocusPainted(false);
-
-       btnGuardar.addActionListener(e -> {
-    try {
-        if (current[0] == null) {
-            Ui.warn(InventoryPage.this, "Primero buscá un insumo por código.");
-            return;
-        }
-        if (!Ui.confirm(InventoryPage.this, "¿Confirmás la modificación de " + current[0].getCodigo() + "?")) {
-            return;
-        }
-
-        // --- Actualizar todos los campos editables ---
-        current[0].setDescripcion(txtDescripcion.getText().trim());
-        current[0].setCategoria((Categoria) cbCategoria.getSelectedItem());
-
-        // 🔹 CAMBIO IMPORTANTE: usar el combo de ubicación en vez del txt
-        current[0].setUbicacion((String) cbUbicacionEdit.getSelectedItem());
-
-        // Validar stock mínimo
-        try {
-            spStockMin.commitEdit();
-        } catch (java.text.ParseException ignore) {}
-        Object v = spStockMin.getValue();
-        if (!(v instanceof Number)) {
-            Ui.warn(InventoryPage.this, "El stock mínimo debe ser numérico.");
-            return;
-        }
-        int stockMin = ((Number) v).intValue();
-        if (stockMin < 0) {
-            Ui.warn(InventoryPage.this, "El stock mínimo no puede ser negativo.");
-            return;
-        }
-        current[0].setStockMinimo(stockMin);
-
-        // Estado
-        current[0].setEstado((String) cbEstado.getSelectedItem());
-
-        // Guardar cambios
-        new JdbcInsumoDao().update(current[0]);
-        Ui.info(InventoryPage.this, "Cambios guardados correctamente.");
-
-    } catch (Exception ex) {
-        Ui.error(InventoryPage.this, ex);
-    }
-});
-
-
-        JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        south.setOpaque(false);
-        south.add(btnGuardar);
-        card.add(south, BorderLayout.SOUTH);
-
-        return card;
-    }
-
-    private CardPanel buildForm(String title, String[][] fields) {
-        CardPanel card = new CardPanel();
-        card.setLayout(new BorderLayout(12, 16));
-
-        JLabel lbl = new JLabel(title.toUpperCase());
-        lbl.setFont(lbl.getFont().deriveFont(Font.BOLD, 16f));
-        lbl.setForeground(new Color(70, 96, 180));
-        card.add(lbl, BorderLayout.NORTH);
-
-        JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
-        form.setOpaque(false);
-
-        for (String[] field : fields) {
-            form.add(fieldPanel(field[0], field[1]));
-        }
-
-        card.add(form, BorderLayout.CENTER);
-
-        JButton btn = new JButton("Aceptar");
-        btn.setPreferredSize(new Dimension(160, 40));
-        btn.setBackground(new Color(58, 96, 224));
-        btn.setForeground(Color.WHITE);
-        btn.setFocusPainted(false);
-
-        JPanel south = new JPanel(new FlowLayout(FlowLayout.CENTER));
-        south.setOpaque(false);
-        south.add(btn);
-        card.add(south, BorderLayout.SOUTH);
-
-        return card;
-    }
-
-    private JPanel fieldPanel(String label, String placeholder) {
-        JPanel p = new JPanel(new BorderLayout(6, 6));
-        p.setOpaque(false);
-        JLabel lbl = new JLabel(label.toUpperCase());
-        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
-        p.add(lbl, BorderLayout.NORTH);
-        JTextField txt = new JTextField();
-        txt.putClientProperty("JTextField.placeholderText", placeholder);
-        txt.putClientProperty("JComponent.roundRect", true);
-        txt.setPreferredSize(new Dimension(200, 40));
-        p.add(txt, BorderLayout.CENTER);
-        return p;
-    }
-
-    private JPanel labeled(String titulo, JComponent field) {
-        JPanel p = new JPanel(new BorderLayout(6, 6));
-        p.setOpaque(false);
-        JLabel lbl = new JLabel(titulo);
-        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
-        p.add(lbl, BorderLayout.NORTH);
-        field.setPreferredSize(new Dimension(180, 28));
-        p.add(field, BorderLayout.CENTER);
-        return p;
     }
 
     private JToggleButton pillButton(String text) {
@@ -780,30 +137,538 @@ form.add(labeled("UBICACIÓN", cbUbicacionEdit));
         return b;
     }
 
-    // Agrega una fila "Etiqueta | Componente" al panel con GridBagLayout.
-    private void addFormRow(JPanel form, int row, String label, JComponent field) {
-        GridBagConstraints gc = new GridBagConstraints();
-        gc.gridy = row;
-
-        gc.gridx = 0;
-        gc.anchor = GridBagConstraints.LINE_END;
-        gc.insets = new Insets(6, 0, 6, 12);
-        form.add(new JLabel(label), gc);
-
-        gc.gridx = 1;
-        gc.anchor = GridBagConstraints.LINE_START;
-        gc.fill = GridBagConstraints.HORIZONTAL;
-        gc.weightx = 1.0;
-        form.add(field, gc);
+    private List<Categoria> categorias() {
+        return service.listarCategorias();
     }
 
-    // Fuerza tamaño compacto para campos
-    private void compactField(JComponent c) {
-        c.setFont(c.getFont().deriveFont(12f));
-        Dimension d = new Dimension(220, 26);
-        c.setPreferredSize(d);
-        c.setMinimumSize(new Dimension(120, 26));
-        c.setMaximumSize(new Dimension(Short.MAX_VALUE, 26));
-        c.putClientProperty("JComponent.sizeVariant", "small");
+    private List<String> ubicaciones() {
+        return service.listarUbicaciones().stream()
+                .map(Ubicacion::getNombre)
+                .filter(Objects::nonNull)
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .toList();
+    }
+
+    private boolean isAdmin() {
+        Usuario u = CurrentSession.getUser();
+        return u != null && u.getRol() != null && u.getRol().getNombre() != null
+                && "ADMIN".equalsIgnoreCase(u.getRol().getNombre());
+    }
+
+    private List<Insumo> buscarInsumos(String query) {
+        String q = query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
+        return service.listarTodos().stream()
+                .filter(i -> {
+                    if (q.isEmpty()) return true;
+                    String cod = i.getCodigo() == null ? "" : i.getCodigo().toLowerCase(Locale.ROOT);
+                    String desc = i.getDescripcion() == null ? "" : i.getDescripcion().toLowerCase(Locale.ROOT);
+                    return cod.contains(q) || desc.contains(q);
+                })
+                .sorted(Comparator.comparing(i -> i.getCodigo() == null ? "" : i.getCodigo()))
+                .toList();
+    }
+
+    private void stylePrimaryButton(JButton b) {
+        b.setPreferredSize(BUTTON_SIZE);
+        b.setBackground(new Color(58, 96, 224));
+        b.setForeground(Color.WHITE);
+        b.setFocusPainted(false);
+    }
+
+    private class RegistroPanel extends CardPanel {
+        private final JTextField txtCodigo = new JTextField();
+        private final JTextField txtDescripcion = new JTextField();
+        private final JComboBox<Categoria> cbCategoria = new JComboBox<>();
+        private final JComboBox<String> cbUbicacion = new JComboBox<>();
+        private final JComboBox<String> cbTipo = new JComboBox<>(new String[]{"INSUMO", "BIEN"});
+        private final JSpinner spStockMin = new JSpinner(new SpinnerNumberModel(0, 0, 999999, 1));
+        private final JButton btnGuardar = new JButton("Guardar");
+
+        RegistroPanel() {
+            setLayout(new BorderLayout(12, 16));
+            setBorder(new EmptyBorder(12, 12, 12, 12));
+
+            JLabel title = new JLabel("Registro de inventario");
+            title.setFont(title.getFont().deriveFont(Font.BOLD, 16f));
+            title.setForeground(new Color(70, 96, 180));
+            add(title, BorderLayout.NORTH);
+
+            JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
+            form.setOpaque(false);
+
+            txtCodigo.putClientProperty("JTextField.placeholderText", "Ej: INS001");
+            txtDescripcion.putClientProperty("JTextField.placeholderText", "Descripción...");
+            cbUbicacion.putClientProperty("JComponent.roundRect", true);
+            cbCategoria.putClientProperty("JComponent.roundRect", true);
+            cbTipo.putClientProperty("JComponent.roundRect", true);
+            spStockMin.setEditor(new JSpinner.NumberEditor(spStockMin, "#"));
+
+            form.add(labeled("CÓDIGO", txtCodigo));
+            form.add(labeled("DESCRIPCIÓN", txtDescripcion));
+            form.add(labeled("CATEGORÍA", cbCategoria));
+            form.add(labeled("UBICACIÓN", cbUbicacion));
+            form.add(labeled("TIPO", cbTipo));
+            form.add(labeled("STOCK MÍNIMO", spStockMin));
+            add(form, BorderLayout.CENTER);
+
+            stylePrimaryButton(btnGuardar);
+            btnGuardar.addActionListener(e -> guardar());
+
+            JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            south.setOpaque(false);
+            south.add(btnGuardar);
+            add(south, BorderLayout.SOUTH);
+
+            refreshCombos();
+        }
+
+        void refreshCombos() {
+            cbCategoria.removeAllItems();
+            for (Categoria c : categorias()) {
+                cbCategoria.addItem(c);
+            }
+
+            cbUbicacion.removeAllItems();
+            for (String nombre : ubicaciones()) {
+                cbUbicacion.addItem(nombre);
+            }
+            if (cbUbicacion.getItemCount() == 0) {
+                cbUbicacion.addItem("-");
+            }
+            cbUbicacion.setSelectedIndex(0);
+        }
+
+        private void guardar() {
+            try {
+                String codigo = txtCodigo.getText().trim();
+                String desc = txtDescripcion.getText().trim();
+                if (codigo.isEmpty() || desc.isEmpty()) {
+                    Ui.warn(this, "Código y descripción son obligatorios.");
+                    return;
+                }
+
+                Categoria categoria = (Categoria) cbCategoria.getSelectedItem();
+                if (categoria == null) {
+                    Ui.warn(this, "Seleccioná una categoría.");
+                    return;
+                }
+
+                Object v = spStockMin.getValue();
+                if (!(v instanceof Number)) {
+                    Ui.warn(this, "El stock mínimo debe ser numérico.");
+                    return;
+                }
+                int stockMin = ((Number) v).intValue();
+
+                Insumo ins = new Insumo();
+                ins.setCodigo(codigo);
+                ins.setDescripcion(desc);
+                ins.setCategoria(categoria);
+                ins.setUbicacion((String) cbUbicacion.getSelectedItem());
+                ins.setStockMinimo(stockMin);
+                ins.setEstado("ACTIVO");
+                ins.setTipo((String) cbTipo.getSelectedItem());
+
+                Long id = service.registrarInsumo(ins);
+                Ui.info(this, "Insumo guardado. ID = " + id);
+
+                txtCodigo.setText("");
+                txtDescripcion.setText("");
+                spStockMin.setValue(0);
+                cbTipo.setSelectedIndex(0);
+                refreshCombos();
+            } catch (IllegalArgumentException ex) {
+                Ui.warn(this, ex.getMessage());
+            } catch (Exception ex) {
+                Ui.error(this, ex);
+            }
+        }
+    }
+
+    private class ModificarPanel extends CardPanel {
+        private final JTextField txtBuscar = new JTextField(18);
+        private final DefaultListModel<Insumo> listModel = new DefaultListModel<>();
+        private final JList<Insumo> lstResultados = new JList<>(listModel);
+
+        private final JTextField txtCodigo = new JTextField();
+        private final JTextField txtDescripcion = new JTextField();
+        private final JComboBox<Categoria> cbCategoria = new JComboBox<>();
+        private final JComboBox<String> cbUbicacion = new JComboBox<>();
+        private final JComboBox<String> cbTipo = new JComboBox<>(new String[]{"INSUMO", "BIEN"});
+        private final JSpinner spStockMin = new JSpinner(new SpinnerNumberModel(0, 0, 999999, 1));
+        private final JComboBox<String> cbEstado = new JComboBox<>(new String[]{"ACTIVO", "INACTIVO"});
+        private final JButton btnGuardar = new JButton("Guardar cambios");
+
+        private Insumo seleccionado;
+
+        ModificarPanel() {
+            setLayout(new BorderLayout(12, 16));
+            setBorder(new EmptyBorder(12, 12, 12, 12));
+
+            JLabel title = new JLabel("Modificar insumo existente");
+            title.setFont(title.getFont().deriveFont(Font.BOLD, 16f));
+            title.setForeground(new Color(70, 96, 180));
+            add(title, BorderLayout.NORTH);
+
+            JPanel content = new JPanel(new BorderLayout(12, 12));
+            content.setOpaque(false);
+            add(content, BorderLayout.CENTER);
+
+            JPanel search = new JPanel(new BorderLayout(8, 0));
+            search.setOpaque(false);
+            txtBuscar.putClientProperty("JTextField.placeholderText", "Código o descripción");
+            JButton btnBuscar = new JButton("Buscar");
+            btnBuscar.addActionListener(e -> cargarResultados());
+            search.add(txtBuscar, BorderLayout.CENTER);
+            search.add(btnBuscar, BorderLayout.EAST);
+            content.add(search, BorderLayout.NORTH);
+
+            lstResultados.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            lstResultados.setVisibleRowCount(8);
+            lstResultados.setCellRenderer(new InsumoRenderer());
+            lstResultados.addListSelectionListener(new ListSelectionListener() {
+                @Override public void valueChanged(ListSelectionEvent e) {
+                    if (!e.getValueIsAdjusting()) {
+                        seleccionado = lstResultados.getSelectedValue();
+                        cargarSeleccionado();
+                    }
+                }
+            });
+
+            JScrollPane scroll = new JScrollPane(lstResultados);
+            scroll.setPreferredSize(new Dimension(260, 180));
+            content.add(scroll, BorderLayout.WEST);
+
+            JPanel form = new JPanel(new GridLayout(0, 2, 18, 18));
+            form.setOpaque(false);
+            txtCodigo.setEditable(false);
+            spStockMin.setEditor(new JSpinner.NumberEditor(spStockMin, "#"));
+            cbCategoria.putClientProperty("JComponent.roundRect", true);
+            cbUbicacion.putClientProperty("JComponent.roundRect", true);
+            cbTipo.putClientProperty("JComponent.roundRect", true);
+            cbEstado.putClientProperty("JComponent.roundRect", true);
+
+            form.add(labeled("CÓDIGO", txtCodigo));
+            form.add(labeled("DESCRIPCIÓN", txtDescripcion));
+            form.add(labeled("CATEGORÍA", cbCategoria));
+            form.add(labeled("UBICACIÓN", cbUbicacion));
+            form.add(labeled("TIPO", cbTipo));
+            form.add(labeled("STOCK MÍNIMO", spStockMin));
+            form.add(labeled("ESTADO", cbEstado));
+            content.add(form, BorderLayout.CENTER);
+
+            stylePrimaryButton(btnGuardar);
+            btnGuardar.addActionListener(e -> guardar());
+            JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            south.setOpaque(false);
+            south.add(btnGuardar);
+            add(south, BorderLayout.SOUTH);
+
+            refreshData();
+        }
+
+        void refreshData() {
+            cargarResultados();
+            cbCategoria.removeAllItems();
+            for (Categoria c : categorias()) cbCategoria.addItem(c);
+
+            cbUbicacion.removeAllItems();
+            for (String nombre : ubicaciones()) cbUbicacion.addItem(nombre);
+            if (cbUbicacion.getItemCount() == 0) cbUbicacion.addItem("-");
+
+            cbEstado.setEnabled(isAdmin());
+        }
+
+        void mostrarSoloBajoMinimo() {
+            refreshData();
+            txtBuscar.setText("");
+            listModel.clear();
+            List<Insumo> insumos = service.listarTodos();
+            for (Insumo i : insumos) {
+                if (i.getId() == null) {
+                    continue;
+                }
+                Integer minimo = i.getStockMinimo();
+                if (minimo == null) {
+                    continue;
+                }
+                BigDecimal actual;
+                try {
+                    actual = service.stockActualExacto(i.getId());
+                } catch (Exception ex) {
+                    actual = BigDecimal.ZERO;
+                }
+                if (actual.compareTo(BigDecimal.valueOf(minimo)) < 0) {
+                    listModel.addElement(i);
+                }
+            }
+            if (listModel.isEmpty()) {
+                limpiarFormulario();
+            } else {
+                lstResultados.setSelectedIndex(0);
+            }
+        }
+
+        private void cargarResultados() {
+            listModel.clear();
+            for (Insumo i : buscarInsumos(txtBuscar.getText())) {
+                listModel.addElement(i);
+            }
+            seleccionado = null;
+            limpiarFormulario();
+        }
+
+        private void limpiarFormulario() {
+            txtCodigo.setText("");
+            txtDescripcion.setText("");
+            if (cbCategoria.getItemCount() > 0) cbCategoria.setSelectedIndex(0);
+            if (cbUbicacion.getItemCount() > 0) cbUbicacion.setSelectedIndex(0);
+            cbTipo.setSelectedIndex(0);
+            spStockMin.setValue(0);
+            cbEstado.setSelectedIndex(0);
+        }
+
+        private void cargarSeleccionado() {
+            if (seleccionado == null) {
+                limpiarFormulario();
+                return;
+            }
+            txtCodigo.setText(seleccionado.getCodigo());
+            txtDescripcion.setText(seleccionado.getDescripcion() == null ? "" : seleccionado.getDescripcion());
+
+            if (seleccionado.getCategoria() != null) {
+                for (int i = 0; i < cbCategoria.getItemCount(); i++) {
+                    if (Objects.equals(cbCategoria.getItemAt(i).getId(), seleccionado.getCategoria().getId())) {
+                        cbCategoria.setSelectedIndex(i);
+                        break;
+                    }
+                }
+            }
+
+            if (seleccionado.getUbicacion() != null) {
+                String ubic = seleccionado.getUbicacion();
+                ComboBoxModel<String> model = cbUbicacion.getModel();
+                boolean found = false;
+                for (int i = 0; i < model.getSize(); i++) {
+                    if (ubic.equalsIgnoreCase(model.getElementAt(i))) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    cbUbicacion.addItem(ubic);
+                }
+                cbUbicacion.setSelectedItem(ubic);
+            }
+            cbTipo.setSelectedItem(seleccionado.getTipo() == null ? "INSUMO" : seleccionado.getTipo());
+
+            Integer sm = seleccionado.getStockMinimo();
+            spStockMin.setValue(sm == null ? 0 : sm);
+            cbEstado.setSelectedItem(seleccionado.getEstado() == null ? "ACTIVO" : seleccionado.getEstado());
+        }
+
+        private void guardar() {
+            if (seleccionado == null) {
+                Ui.warn(this, "Primero seleccioná un insumo de la lista.");
+                return;
+            }
+            try {
+                seleccionado.setDescripcion(txtDescripcion.getText().trim());
+                seleccionado.setCategoria((Categoria) cbCategoria.getSelectedItem());
+                seleccionado.setUbicacion((String) cbUbicacion.getSelectedItem());
+                seleccionado.setTipo((String) cbTipo.getSelectedItem());
+
+                spStockMin.commitEdit();
+                Object v = spStockMin.getValue();
+                if (!(v instanceof Number)) {
+                    Ui.warn(this, "El stock mínimo debe ser numérico.");
+                    return;
+                }
+                seleccionado.setStockMinimo(((Number) v).intValue());
+
+                if (isAdmin()) {
+                    seleccionado.setEstado((String) cbEstado.getSelectedItem());
+                }
+
+                service.editarInsumo(seleccionado);
+                Ui.info(this, "Cambios guardados correctamente.");
+                cargarResultados();
+            } catch (IllegalStateException ex) {
+                Ui.warn(this, ex.getMessage());
+            } catch (IllegalArgumentException ex) {
+                Ui.warn(this, ex.getMessage());
+            } catch (Exception ex) {
+                Ui.error(this, ex);
+            }
+        }
+    }
+
+    private class EliminarPanel extends CardPanel {
+        private final JTextField txtBuscar = new JTextField(18);
+        private final DefaultListModel<Insumo> listModel = new DefaultListModel<>();
+        private final JList<Insumo> lstResultados = new JList<>(listModel);
+
+        private final JTextField txtCodigo = new JTextField();
+        private final JTextField txtDescripcion = new JTextField();
+        private final JTextField txtCategoria = new JTextField();
+        private final JTextField txtUbicacion = new JTextField();
+        private final JTextField txtTipo = new JTextField();
+        private final JTextField txtEstado = new JTextField();
+        private final JLabel lblStock = new JLabel(" ");
+        private final JButton btnEliminar = new JButton("Eliminar");
+
+        private Insumo seleccionado;
+        private BigDecimal stockActual = BigDecimal.ZERO;
+
+        EliminarPanel() {
+            setLayout(new BorderLayout(12, 16));
+            setBorder(new EmptyBorder(12, 12, 12, 12));
+
+            JLabel title = new JLabel("Baja lógica de insumo");
+            title.setFont(title.getFont().deriveFont(Font.BOLD, 16f));
+            title.setForeground(new Color(180, 70, 70));
+            add(title, BorderLayout.NORTH);
+
+            JPanel content = new JPanel(new BorderLayout(12, 12));
+            content.setOpaque(false);
+            add(content, BorderLayout.CENTER);
+
+            JPanel search = new JPanel(new BorderLayout(8, 0));
+            search.setOpaque(false);
+            txtBuscar.putClientProperty("JTextField.placeholderText", "Código o descripción");
+            JButton btnBuscar = new JButton("Buscar");
+            btnBuscar.addActionListener(e -> cargarResultados());
+            search.add(txtBuscar, BorderLayout.CENTER);
+            search.add(btnBuscar, BorderLayout.EAST);
+            content.add(search, BorderLayout.NORTH);
+
+            lstResultados.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            lstResultados.setVisibleRowCount(8);
+            lstResultados.setCellRenderer(new InsumoRenderer());
+            lstResultados.addListSelectionListener(e -> {
+                if (!e.getValueIsAdjusting()) {
+                    seleccionado = lstResultados.getSelectedValue();
+                    cargarSeleccionado();
+                }
+            });
+            content.add(new JScrollPane(lstResultados), BorderLayout.WEST);
+
+            JPanel form = new JPanel(new GridLayout(0, 2, 18, 12));
+            form.setOpaque(false);
+            for (JTextField tf : new JTextField[]{txtCodigo, txtDescripcion, txtCategoria, txtUbicacion, txtTipo, txtEstado}) {
+                tf.setEditable(false);
+            }
+            form.add(labeled("CÓDIGO", txtCodigo));
+            form.add(labeled("DESCRIPCIÓN", txtDescripcion));
+            form.add(labeled("CATEGORÍA", txtCategoria));
+            form.add(labeled("UBICACIÓN", txtUbicacion));
+            form.add(labeled("TIPO", txtTipo));
+            form.add(labeled("ESTADO", txtEstado));
+            content.add(form, BorderLayout.CENTER);
+
+            lblStock.setForeground(new Color(200, 90, 90));
+            lblStock.setFont(lblStock.getFont().deriveFont(Font.BOLD, 12f));
+
+            stylePrimaryButton(btnEliminar);
+            btnEliminar.setBackground(new Color(200, 60, 60));
+            btnEliminar.addActionListener(e -> eliminar());
+            btnEliminar.setEnabled(false);
+
+            JPanel south = new JPanel(new BorderLayout());
+            south.setOpaque(false);
+            south.add(lblStock, BorderLayout.WEST);
+            JPanel btnRow = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+            btnRow.setOpaque(false);
+            btnRow.add(btnEliminar);
+            south.add(btnRow, BorderLayout.EAST);
+            add(south, BorderLayout.SOUTH);
+
+            refreshData();
+        }
+
+        void refreshData() {
+            cargarResultados();
+        }
+
+        private void cargarResultados() {
+            listModel.clear();
+            for (Insumo i : buscarInsumos(txtBuscar.getText())) listModel.addElement(i);
+            seleccionado = null;
+            limpiarFormulario();
+        }
+
+        private void limpiarFormulario() {
+            for (JTextField tf : new JTextField[]{txtCodigo, txtDescripcion, txtCategoria, txtUbicacion, txtTipo, txtEstado}) {
+                tf.setText("");
+            }
+            lblStock.setText(" ");
+            btnEliminar.setEnabled(false);
+        }
+
+        private void cargarSeleccionado() {
+            if (seleccionado == null) {
+                limpiarFormulario();
+                return;
+            }
+            txtCodigo.setText(seleccionado.getCodigo());
+            txtDescripcion.setText(seleccionado.getDescripcion() == null ? "" : seleccionado.getDescripcion());
+            txtCategoria.setText(seleccionado.getCategoria() != null ? seleccionado.getCategoria().getNombre() : "");
+            txtUbicacion.setText(seleccionado.getUbicacion() == null ? "" : seleccionado.getUbicacion());
+            txtTipo.setText(seleccionado.getTipo() == null ? "INSUMO" : seleccionado.getTipo());
+            txtEstado.setText(seleccionado.getEstado() == null ? "ACTIVO" : seleccionado.getEstado());
+
+            stockActual = service.stockActualExacto(seleccionado.getId());
+            if (stockActual.compareTo(BigDecimal.ZERO) > 0) {
+                lblStock.setText("Stock: " + stockActual.stripTrailingZeros().toPlainString() + " (no eliminable)");
+                btnEliminar.setEnabled(false);
+            } else {
+                lblStock.setText("Stock: 0");
+                btnEliminar.setEnabled(true);
+            }
+        }
+
+        private void eliminar() {
+            if (seleccionado == null) {
+                Ui.warn(this, "Seleccioná un insumo.");
+                return;
+            }
+            if (!Ui.confirm(this, "¿Confirmás la baja lógica de " + seleccionado.getCodigo() + "?")) {
+                return;
+            }
+            try {
+                service.bajaLogica(seleccionado.getId());
+                Ui.info(this, "El insumo fue dado de baja.");
+                cargarResultados();
+            } catch (IllegalStateException ex) {
+                Ui.warn(this, ex.getMessage());
+            } catch (Exception ex) {
+                Ui.error(this, ex);
+            }
+        }
+    }
+
+    private JPanel labeled(String titulo, JComponent field) {
+        JPanel p = new JPanel(new BorderLayout(6, 6));
+        p.setOpaque(false);
+        JLabel lbl = new JLabel(titulo);
+        lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN, 12f));
+        p.add(lbl, BorderLayout.NORTH);
+        field.setPreferredSize(new Dimension(220, 28));
+        p.add(field, BorderLayout.CENTER);
+        return p;
+    }
+
+    private static class InsumoRenderer extends DefaultListCellRenderer {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value instanceof Insumo ins) {
+                String cod = ins.getCodigo() == null ? "-" : ins.getCodigo();
+                String desc = ins.getDescripcion() == null ? "" : ins.getDescripcion();
+                String tipo = ins.getTipo() == null ? "INSUMO" : ins.getTipo();
+                setText(cod + " · " + desc + " · " + tipo);
+            }
+            return this;
+        }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -48,11 +48,13 @@ public class TramiteEntradaPage extends JPanel {
     // --- Filtros de la tabla ---
     private final JTextField filterSearch = new JTextField(18);
     private final JComboBox<String> filterEstado = new JComboBox<>(
-            new String[]{"Todos", "Completado", "En proceso", "Pendiente"}
+            new String[]{"Todos", "Completado", "En proceso", "Pendiente", "Nuevo"}
     );
 
     private final CardLayout cardLayout = new CardLayout();
     private final JPanel cards = new JPanel(cardLayout);
+    private JToggleButton tabRegistrar;
+    private JToggleButton tabActivos;
 
     // Tabla (solo columna Estado editable)
     private final JTable table = new JTable(new DefaultTableModel(
@@ -156,20 +158,20 @@ public class TramiteEntradaPage extends JPanel {
         header.add(title, BorderLayout.WEST);
 
         ButtonGroup tabs = new ButtonGroup();
-        JToggleButton btnRegistrar = tabButton("Registrar nuevo trámite");
-        JToggleButton btnActivos   = tabButton("Trámites activos");
-        tabs.add(btnRegistrar);
-        tabs.add(btnActivos);
-        btnRegistrar.setSelected(true);
+        tabRegistrar = tabButton("Registrar nuevo trámite");
+        tabActivos   = tabButton("Trámites activos");
+        tabs.add(tabRegistrar);
+        tabs.add(tabActivos);
+        tabRegistrar.setSelected(true);
 
         JPanel switches = new JPanel(new FlowLayout(FlowLayout.RIGHT, 12, 0));
         switches.setOpaque(false);
-        switches.add(btnRegistrar);
-        switches.add(btnActivos);
+        switches.add(tabRegistrar);
+        switches.add(tabActivos);
         header.add(switches, BorderLayout.EAST);
 
-        btnRegistrar.addActionListener(e -> cardLayout.show(cards, "registro"));
-        btnActivos.addActionListener(e -> {
+        tabRegistrar.addActionListener(e -> cardLayout.show(cards, "registro"));
+        tabActivos.addActionListener(e -> {
             loadTableData();
             cardLayout.show(cards, "activos");
         });
@@ -471,6 +473,28 @@ private CardPanel recentTramitesCard() {
         } catch (Exception ex) {
             Ui.error(this, ex);
         }
+    }
+
+    public void mostrarTramitesEstado(String estado) {
+        SwingUtilities.invokeLater(() -> {
+            if (tabActivos != null) {
+                tabActivos.setSelected(true);
+            }
+            cardLayout.show(cards, "activos");
+
+            String friendly = estadoFriendly(estado);
+            if (friendly != null) {
+                for (int i = 0; i < filterEstado.getItemCount(); i++) {
+                    String item = filterEstado.getItemAt(i);
+                    if (item != null && item.equalsIgnoreCase(friendly)) {
+                        filterEstado.setSelectedIndex(i);
+                        break;
+                    }
+                }
+            }
+            filterSearch.setText("");
+            loadTableData();
+        });
     }
 
     private boolean estadoMatches(String estado, String filtro) {

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -14,6 +14,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.*;
 import javax.swing.text.MaskFormatter;
 import java.awt.*;
+import java.math.BigDecimal;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -60,6 +61,7 @@ public class InformesPanel extends JPanel {
     private final JComboBox<Categoria> cbCategoria = new JComboBox<>();
     private final DateField dfDesde = new DateField();
     private final DateField dfHasta = new DateField();
+    private final JCheckBox chkSoloBajoMinimo = new JCheckBox("Solo bajo mínimo");
     private final DefaultTableModel modelInv = new DefaultTableModel(
             new Object[]{"Código", "Descripción", "Estado", "Fecha"}, 0
     ) {
@@ -85,7 +87,7 @@ public class InformesPanel extends JPanel {
     // --- MOVIMIENTOS (similar a Trámites de UI) ---
     private final JTextField filterSearchMov = new JTextField(18);
     private final DefaultTableModel modelMov = new DefaultTableModel(
-            new Object[]{"Código", "Descripción", "Ubicación", "Entrada", "Salida", "Stock actual", "Fecha"}, 0
+            new Object[]{"Fecha", "Tipo", "Cantidad", "Código", "Descripción", "Ubicación", "Destino/Fuente"}, 0
     ) {
         @Override
         public boolean isCellEditable(int r, int c) {
@@ -144,6 +146,26 @@ public class InformesPanel extends JPanel {
 
         loadTableDataMovimientos();
         installFiltersMovimientos();
+    }
+
+    public void mostrarInventarioBajoMinimo() {
+        if (btnInventario != null) {
+            btnInventario.setSelected(true);
+            contentCards.show(content, "INV");
+        }
+        chkSoloBajoMinimo.setSelected(true);
+        runQueryInventario();
+    }
+
+    public void mostrarMovimientosSalidasHoy() {
+        if (btnMovimientos != null) {
+            btnMovimientos.setSelected(true);
+            contentCards.show(content, "MOV");
+        }
+        cbTipoMov.setSelectedItem("Salida");
+        cbPeriodoMov.setSelectedItem("Hoy");
+        txtFiltroMov.setText("");
+        loadTableDataMovimientos();
     }
 
     // ====== Header (título centrado + export) ======
@@ -356,6 +378,10 @@ public class InformesPanel extends JPanel {
         fields.add(leftField("Desde", desdeComp));
         fields.add(Box.createVerticalStrut(18));
         fields.add(leftField("Hasta", hastaComp));
+        chkSoloBajoMinimo.setOpaque(false);
+        chkSoloBajoMinimo.addActionListener(e -> runQueryInventario());
+        fields.add(Box.createVerticalStrut(18));
+        fields.add(chkSoloBajoMinimo);
         fields.add(Box.createVerticalStrut(28));
 
         // Botón
@@ -577,6 +603,20 @@ public class InformesPanel extends JPanel {
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
             List<Insumo> data = filtrarLocal(invService.listarTodos(), cat, d1, d2);
+            if (chkSoloBajoMinimo.isSelected()) {
+                data = data.stream()
+                        .filter(i -> {
+                            Integer minimo = i.getStockMinimo();
+                            if (minimo == null || i.getId() == null) return false;
+                            try {
+                                BigDecimal stock = invService.stockActualExacto(i.getId());
+                                return stock.compareTo(BigDecimal.valueOf(minimo)) < 0;
+                            } catch (Exception ex) {
+                                return false;
+                            }
+                        })
+                        .collect(Collectors.toList());
+            }
             for (Insumo i : data) {
                 LocalDate fa = i.getFechaAlta();
                 if (fa == null && i.getCreatedAt() != null) {
@@ -864,6 +904,8 @@ public class InformesPanel extends JPanel {
     private final JTextField filterMovSearch = new JTextField(18);
     private final JComboBox<String> filterMovTipo
             = new JComboBox<>(new String[]{"Todos", "Entrada", "Salida"});
+    private final JComboBox<String> cbPeriodoMov
+            = new JComboBox<>(new String[]{"Todos", "Hoy", "Últimos 7 días"});
 
     // == MOVIMIENTOS: fila de filtros (usa SIEMPRE los campos txtFiltroMov y cbTipoMov) ==
     private JComponent buildMovimientosFilters() {
@@ -886,6 +928,9 @@ public class InformesPanel extends JPanel {
         styleFilterField(cbTipoMov, 140); // {Todos, Entrada, Salida}
         fields.add(cbTipoMov);
 
+        styleFilterField(cbPeriodoMov, 140);
+        fields.add(cbPeriodoMov);
+
         // Listeners para refrescar:
         if (txtFiltroMov.getDocument() != null) {
             txtFiltroMov.getDocument().addDocumentListener(new SimpleDocumentListener() {
@@ -896,6 +941,7 @@ public class InformesPanel extends JPanel {
             });
         }
         cbTipoMov.addActionListener(e -> loadTableDataMovimientos());
+        cbPeriodoMov.addActionListener(e -> loadTableDataMovimientos());
 
         panel.add(fields, BorderLayout.CENTER);
         return panel;
@@ -923,13 +969,13 @@ public class InformesPanel extends JPanel {
         // Anchos
         TableColumnModel tcm = table.getColumnModel();
         if (tcm.getColumnCount() >= 7) {
-            tcm.getColumn(0).setPreferredWidth(140); // Código
-            tcm.getColumn(1).setPreferredWidth(240); // Descripción
-            tcm.getColumn(2).setPreferredWidth(160); // Ubicación
-            tcm.getColumn(3).setPreferredWidth(110); // Entrada
-            tcm.getColumn(4).setPreferredWidth(110); // Salida
-            tcm.getColumn(5).setPreferredWidth(120); // Stock actual
-            tcm.getColumn(6).setPreferredWidth(140); // Fecha
+            tcm.getColumn(0).setPreferredWidth(160); // Fecha
+            tcm.getColumn(1).setPreferredWidth(90);  // Tipo
+            tcm.getColumn(2).setPreferredWidth(110); // Cantidad
+            tcm.getColumn(3).setPreferredWidth(140); // Código
+            tcm.getColumn(4).setPreferredWidth(220); // Descripción
+            tcm.getColumn(5).setPreferredWidth(160); // Ubicación
+            tcm.getColumn(6).setPreferredWidth(200); // Destino
         }
 
         JTableHeader header = table.getTableHeader();
@@ -967,7 +1013,6 @@ public class InformesPanel extends JPanel {
     private void loadTableDataMovimientos() {
         modelMov.setRowCount(0);
         try {
-            // Leer filtros
             String search = (txtFiltroMov != null && txtFiltroMov.getText() != null)
                     ? txtFiltroMov.getText().trim().toLowerCase()
                     : "";
@@ -976,59 +1021,69 @@ public class InformesPanel extends JPanel {
                     ? cbTipoMov.getSelectedItem().toString().trim()
                     : "Todos";
 
-            String tipoNorm = tipoSel.toLowerCase(); // "todos" | "entrada" | "salida"
+            String periodoSel = (cbPeriodoMov != null && cbPeriodoMov.getSelectedItem() != null)
+                    ? cbPeriodoMov.getSelectedItem().toString().trim()
+                    : "Todos";
 
-            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            String tipoFiltro = switch (tipoSel.toUpperCase()) {
+                case "ENTRADA" -> "ENTRADA";
+                case "SALIDA" -> "SALIDA";
+                default -> null;
+            };
 
-            for (Insumo i : invService.listarTodos()) {
+            java.time.LocalDate hoy = java.time.LocalDate.now();
+            java.time.LocalDate desde = null;
+            java.time.LocalDate hasta = null;
+            switch (periodoSel.toUpperCase()) {
+                case "HOY" -> {
+                    desde = hoy;
+                    hasta = hoy;
+                }
+                case "ÚLTIMOS 7 DÍAS" -> {
+                    hasta = hoy;
+                    desde = hoy.minusDays(6);
+                }
+            }
 
-                // Filtro por texto libre
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+            List<Movimiento> movimientos = invService.movimientosPorFechaYTipo(desde, hasta, tipoFiltro);
+            for (Movimiento m : movimientos) {
+                String codigo = (m.getInsumo() != null && m.getInsumo().getCodigo() != null)
+                        ? m.getInsumo().getCodigo() : "-";
+                String desc = (m.getInsumo() != null && m.getInsumo().getDescripcion() != null)
+                        ? m.getInsumo().getDescripcion() : "-";
+                String ubic = (m.getInsumo() != null && m.getInsumo().getUbicacion() != null
+                        && !m.getInsumo().getUbicacion().isBlank())
+                        ? m.getInsumo().getUbicacion() : "-";
+
                 if (!search.isEmpty()) {
-                    String src = ((i.getCodigo() == null ? "" : i.getCodigo())
-                            + " " + (i.getDescripcion() == null ? "" : i.getDescripcion()))
+                    String src = (codigo + " " + desc + " " + ubic
+                            + " " + (m.getDestinoFuente() == null ? "" : m.getDestinoFuente()))
                             .toLowerCase();
                     if (!src.contains(search)) {
                         continue;
                     }
                 }
 
-                // Datos base
-                String codigo = i.getCodigo() == null ? "-" : i.getCodigo();
-                String desc = i.getDescripcion() == null ? "-" : i.getDescripcion();
-                String ubicacion = (i.getUbicacion() == null || i.getUbicacion().isBlank())
-                        ? "-" : i.getUbicacion();
+                String fecha = m.getFecha() != null ? m.getFecha().format(fmt) : "-";
+                String cantidad = formatCantidad(m.getCantidad());
+                String destino = (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank())
+                        ? "-" : m.getDestinoFuente();
 
-                String fechaAlta = "-";
-                if (i.getFechaAlta() != null) {
-                    fechaAlta = i.getFechaAlta().format(fmt);
-                } else if (i.getCreatedAt() != null) {
-                    var ld = java.time.ZonedDateTime.ofInstant(i.getCreatedAt(),
-                            java.time.ZoneId.systemDefault()).toLocalDate();
-                    fechaAlta = ld.format(fmt);
-                }
-
-                long insumoId = i.getId();
-                int entradas = invService.totalEntradasDeInsumo(insumoId);
-                int salidas = invService.totalSalidasDeInsumo(insumoId);
-                int stock = invService.stockActual(insumoId);
-
-                // Filtro por tipo (descarta los 0 cuando corresponde)
-                if ("entrada".equals(tipoNorm) && entradas <= 0) {
-                    continue;
-                }
-                if ("salida".equals(tipoNorm) && salidas <= 0) {
-                    continue;
-                }
-
-                modelMov.addRow(new Object[]{codigo, desc, ubicacion, entradas, salidas, stock, fechaAlta});
+                modelMov.addRow(new Object[]{fecha, m.getTipo(), cantidad, codigo, desc, ubic, destino});
             }
 
         } catch (Exception ex) {
-            ex.printStackTrace();
             JOptionPane.showMessageDialog(this,
                     "Error cargando informe de movimientos:\n" + ex.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    private String formatCantidad(java.math.BigDecimal valor) {
+        if (valor == null) return "0";
+        return valor.stripTrailingZeros().toPlainString();
     }
 
     // --- MOVIMIENTOS (filtros) ---

--- a/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
@@ -8,7 +8,6 @@ import ar.edu.unse.siga.ui.base.CardPanel;
 import ar.edu.unse.siga.ui.base.GradientPanel;
 import ar.edu.unse.siga.ui.base.ThemeManager;
 import ar.edu.unse.siga.ui.base.WaveSidebarPanel;
-import ar.edu.unse.siga.ui.pages.FinanzasPage;
 import ar.edu.unse.siga.ui.pages.HomePage;
 import ar.edu.unse.siga.ui.pages.InventoryMovementsPage;
 import ar.edu.unse.siga.ui.pages.InventoryPage;
@@ -34,8 +33,11 @@ public class ShellFrame extends JFrame {
     private final TramiteService tramiteService;
     private final AuthService authService;
 
-    // === NUEVO: referencia a la página de movimientos para refrescar ===
+    private HomePage homePage;
+    private InventoryPage inventoryPage;
     private InventoryMovementsPage movimientosPage;
+    private TramiteEntradaPage tramitesPage;
+    private InformesPanel informesPanel;
 
     // mapa de clave de tarjeta -> botón del sidebar
     private final Map<String, NavButton> navByKey = new HashMap<>();
@@ -81,19 +83,51 @@ public class ShellFrame extends JFrame {
             showCard(key, title);
         };
 
-        // ===== Páginas (instancias compartidas) =====
-        HomePage homePage = new HomePage(CurrentSession.getUser(), inventarioService, tramiteService, nav);
-        TramiteEntradaPage tramitesPage = new TramiteEntradaPage(tramiteService, homePage::recargarTramitesRecientes);
+        inventoryPage = new InventoryPage(inventarioService);
+        informesPanel = new InformesPanel(inventarioService, tramiteService);
+
+        final TramiteEntradaPage[] tramitesHolder = new TramiteEntradaPage[1];
+        homePage = new HomePage(CurrentSession.getUser(), inventarioService, tramiteService, new HomePage.HomeNavigation() {
+            @Override
+            public void navigateTo(String key) {
+                nav.accept(key);
+            }
+
+            @Override
+            public void openInventarioBajoMinimo() {
+                nav.accept("inventario");
+                if (inventoryPage != null) {
+                    inventoryPage.mostrarInsumosBajoMinimo();
+                }
+            }
+
+            @Override
+            public void openTramitesNuevos() {
+                nav.accept("tramites");
+                if (tramitesHolder[0] != null) {
+                    tramitesHolder[0].mostrarTramitesEstado("NUEVO");
+                }
+            }
+
+            @Override
+            public void openMovimientosHoy() {
+                nav.accept("reportes");
+                if (informesPanel != null) {
+                    informesPanel.mostrarMovimientosSalidasHoy();
+                }
+            }
+        });
+
+        tramitesPage = new TramiteEntradaPage(tramiteService, homePage::recargarTramitesRecientes);
+        tramitesHolder[0] = tramitesPage;
+
+        movimientosPage = new InventoryMovementsPage(inventarioService);
 
         addPage("home", homePage);
-        addPage("inventario", new InventoryPage(inventarioService));
-
-        // === NUEVO: instanciar y guardar referencia ===
-        movimientosPage = new InventoryMovementsPage(inventarioService);
+        addPage("inventario", inventoryPage);
         addPage("movimientos", movimientosPage);
-
         addPage("tramites", tramitesPage);
-        addPage("reportes", new InformesPanel(inventarioService, tramiteService));
+        addPage("reportes", informesPanel);
         // addPage("finanzas",    new FinanzasPage()); // si la usás, descomentar
 
         setSize(1200, 760);


### PR DESCRIPTION
## Summary
- Add persistence for the new inventory tipo field and ubicacion catalog plus enforce revised business rules in the service layer
- Refresh inventory and movement Swing screens to expose tipo, catalog-driven ubicaciones, and rule-aware controls
- Make the dashboard KPIs interactive and route to filtered inventory, trámites, and informes views

## Testing
- mvn -q -DskipTests package *(fails: cannot download org.junit:junit-bom because repo.maven.apache.org returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f968e4f5ec8321a76bcf02e8cd3aa0