### PR TITLE
Add advanced inventory settings and capture solicitante in movements

### DIFF
--- a/db/migrations/004_inventario_catalogos_activo.sql
+++ b/db/migrations/004_inventario_catalogos_activo.sql
@@ -1,0 +1,14 @@
+-- Agrega bandera de estado a catálogos y solicitante en movimientos
+ALTER TABLE categoria
+    ADD COLUMN IF NOT EXISTS activo TINYINT(1) NOT NULL DEFAULT 1 AFTER nombre;
+
+ALTER TABLE ubicacion
+    ADD COLUMN IF NOT EXISTS activo TINYINT(1) NOT NULL DEFAULT 1 AFTER nombre;
+
+-- Las filas existentes quedan activas
+UPDATE categoria SET activo = 1 WHERE activo IS NULL;
+UPDATE ubicacion SET activo = 1 WHERE activo IS NULL;
+
+-- Nuevo campo para guardar el solicitante real del movimiento
+ALTER TABLE movimiento
+    ADD COLUMN IF NOT EXISTS solicitante VARCHAR(150) NULL AFTER destino_fuente;

--- a/src/main/java/ar/edu/unse/siga/domain/Categoria.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Categoria.java
@@ -3,12 +3,19 @@ package ar.edu.unse.siga.domain;
 public class Categoria {
     private int id;
     private String nombre;
+    private boolean activa = true;
 
     public Categoria() {}
 
     public Categoria(int id, String nombre) {
         this.id = id;
         this.nombre = nombre;
+    }
+
+    public Categoria(int id, String nombre, boolean activa) {
+        this.id = id;
+        this.nombre = nombre;
+        this.activa = activa;
     }
 
     public Categoria(String nombre) {
@@ -19,6 +26,14 @@ public class Categoria {
     public void setId(int id) { this.id = id; }
     public String getNombre() { return nombre; }
     public void setNombre(String nombre) { this.nombre = nombre; }
+
+    public boolean isActiva() {
+        return activa;
+    }
+
+    public void setActiva(boolean activa) {
+        this.activa = activa;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
@@ -13,6 +13,7 @@ public class Movimiento {
     private String tipo; // ENTRADA / SALIDA
     private java.math.BigDecimal cantidad;
     private String destinoFuente;
+    private String solicitante;
     private LocalDateTime fecha;
     private Usuario usuario;
 
@@ -28,6 +29,8 @@ public class Movimiento {
     public void setCantidad(java.math.BigDecimal cantidad) { this.cantidad = cantidad; }
     public String getDestinoFuente() { return destinoFuente; }
     public void setDestinoFuente(String destinoFuente) { this.destinoFuente = destinoFuente; }
+    public String getSolicitante() { return solicitante; }
+    public void setSolicitante(String solicitante) { this.solicitante = solicitante; }
     public LocalDateTime getFecha() { return fecha; }
     public void setFecha(LocalDateTime fecha) { this.fecha = fecha; }
     public Usuario getUsuario() { return usuario; }

--- a/src/main/java/ar/edu/unse/siga/domain/Ubicacion.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Ubicacion.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 public class Ubicacion {
     private Integer id;
     private String nombre;
+    private boolean activa = true;
 
     public Ubicacion() {}
 
@@ -13,11 +14,25 @@ public class Ubicacion {
         this.nombre = nombre;
     }
 
+    public Ubicacion(Integer id, String nombre, boolean activa) {
+        this.id = id;
+        this.nombre = nombre;
+        this.activa = activa;
+    }
+
     public Integer getId() { return id; }
     public void setId(Integer id) { this.id = id; }
 
     public String getNombre() { return nombre; }
     public void setNombre(String nombre) { this.nombre = nombre; }
+
+    public boolean isActiva() {
+        return activa;
+    }
+
+    public void setActiva(boolean activa) {
+        this.activa = activa;
+    }
 
     @Override public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/CategoriaDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/CategoriaDao.java
@@ -12,11 +12,17 @@ public interface CategoriaDao {
     
     void update(Categoria categoria);
 
+    void softDelete(int id);
+
+    void restore(int id);
+
     boolean deleteIfOrphan(int id);   // true si borró, false si tenía insumos asociados
 
     int countUsos(int id);            // cuántos insumos referencian esta categoría
-    
+
     List<Categoria> findAllOrderByNombre();
+
+    List<Categoria> listAllIncludingInactive();
 
 
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/UbicacionDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/UbicacionDao.java
@@ -6,4 +6,14 @@ import java.util.List;
 
 public interface UbicacionDao {
     List<Ubicacion> listAll();
+
+    List<Ubicacion> listAllIncludingInactive();
+
+    Ubicacion create(Ubicacion ubicacion);
+
+    void update(Ubicacion ubicacion);
+
+    void softDelete(int id);
+
+    void restore(int id);
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcCategoriaDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcCategoriaDao.java
@@ -11,7 +11,7 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public List<Categoria> findAllOrderByNombre() {
-        String sql = "SELECT id, nombre FROM categoria ORDER BY nombre ASC";
+        String sql = "SELECT id, nombre, activo FROM categoria WHERE activo = 1 ORDER BY nombre ASC";
         List<Categoria> out = new ArrayList<>();
         try (Connection c = DataSourceFactory.getConnection();
              PreparedStatement ps = c.prepareStatement(sql);
@@ -20,6 +20,7 @@ public class JdbcCategoriaDao implements CategoriaDao {
                 Categoria cat = new Categoria();
                 cat.setId(rs.getInt("id")); // ← usar int para ser consistente
                 cat.setNombre(rs.getString("nombre"));
+                cat.setActiva(rs.getBoolean("activo"));
                 out.add(cat);
             }
         } catch (SQLException e) {
@@ -30,11 +31,12 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public void create(Categoria categoria) {
-        String sql = "INSERT INTO categoria(nombre) VALUES(?)";
+        String sql = "INSERT INTO categoria(nombre, activo) VALUES(?, 1)";
         try (Connection conn = DataSourceFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setString(1, categoria.getNombre());
             ps.executeUpdate();
+            categoria.setActiva(true);
 
             try (ResultSet rs = ps.getGeneratedKeys()) {
                 if (rs.next()) {
@@ -48,13 +50,16 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public Optional<Categoria> findById(int id) {
-        String sql = "SELECT * FROM categoria WHERE id=?";
+        String sql = "SELECT id, nombre, activo FROM categoria WHERE id=?";
         try (Connection conn = DataSourceFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return Optional.of(new Categoria(rs.getInt("id"), rs.getString("nombre")));
+                    return Optional.of(new Categoria(
+                            rs.getInt("id"),
+                            rs.getString("nombre"),
+                            rs.getBoolean("activo")));
                 }
             }
         } catch (SQLException e) {
@@ -65,13 +70,16 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public Optional<Categoria> findByNombre(String nombre) {
-        String sql = "SELECT * FROM categoria WHERE nombre=?";
+        String sql = "SELECT id, nombre, activo FROM categoria WHERE nombre=?";
         try (Connection conn = DataSourceFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, nombre);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return Optional.of(new Categoria(rs.getInt("id"), rs.getString("nombre")));
+                    return Optional.of(new Categoria(
+                            rs.getInt("id"),
+                            rs.getString("nombre"),
+                            rs.getBoolean("activo")));
                 }
             }
         } catch (SQLException e) {
@@ -82,13 +90,16 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public List<Categoria> listAll() {
-        String sql = "SELECT * FROM categoria ORDER BY nombre";
+        String sql = "SELECT id, nombre, activo FROM categoria WHERE activo = 1 ORDER BY nombre";
         List<Categoria> result = new ArrayList<>();
         try (Connection conn = DataSourceFactory.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
             while (rs.next()) {
-                result.add(new Categoria(rs.getInt("id"), rs.getString("nombre")));
+                result.add(new Categoria(
+                        rs.getInt("id"),
+                        rs.getString("nombre"),
+                        rs.getBoolean("activo")));
             }
         } catch (SQLException e) {
             throw new RuntimeException("Error listando categorías", e);
@@ -98,14 +109,39 @@ public class JdbcCategoriaDao implements CategoriaDao {
 
     @Override
     public void update(Categoria categoria) {
-        String sql = "UPDATE categoria SET nombre=? WHERE id=?";
+        String sql = "UPDATE categoria SET nombre=?, activo=? WHERE id=?";
         try (var conn = DataSourceFactory.getConnection();
              var ps = conn.prepareStatement(sql)) {
             ps.setString(1, categoria.getNombre());
-            ps.setInt(2, categoria.getId());
+            ps.setBoolean(2, categoria.isActiva());
+            ps.setInt(3, categoria.getId());
             ps.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException("Error actualizando categoría id=" + categoria.getId(), e);
+        }
+    }
+
+    @Override
+    public void softDelete(int id) {
+        String sql = "UPDATE categoria SET activo = 0 WHERE id = ?";
+        try (var conn = DataSourceFactory.getConnection();
+             var ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error dando de baja la categoría id=" + id, e);
+        }
+    }
+
+    @Override
+    public void restore(int id) {
+        String sql = "UPDATE categoria SET activo = 1 WHERE id = ?";
+        try (var conn = DataSourceFactory.getConnection();
+             var ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error restaurando la categoría id=" + id, e);
         }
     }
 
@@ -127,14 +163,26 @@ public class JdbcCategoriaDao implements CategoriaDao {
     @Override
     public boolean deleteIfOrphan(int id) {
         if (countUsos(id) > 0) return false;
-        String sql = "DELETE FROM categoria WHERE id=?";
-        try (var conn = DataSourceFactory.getConnection();
-             var ps = conn.prepareStatement(sql)) {
-            ps.setInt(1, id);
-            ps.executeUpdate();
-            return true;
+        softDelete(id);
+        return true;
+    }
+
+    @Override
+    public List<Categoria> listAllIncludingInactive() {
+        String sql = "SELECT id, nombre, activo FROM categoria ORDER BY nombre";
+        List<Categoria> result = new ArrayList<>();
+        try (Connection conn = DataSourceFactory.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                result.add(new Categoria(
+                        rs.getInt("id"),
+                        rs.getString("nombre"),
+                        rs.getBoolean("activo")));
+            }
         } catch (SQLException e) {
-            throw new RuntimeException("Error eliminando categoría id=" + id, e);
+            throw new RuntimeException("Error listando categorías", e);
         }
+        return result;
     }
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
@@ -48,8 +48,8 @@ public class JdbcMovimientoDao implements MovimientoDao {
         }
 
         final String insertSql = """
-            INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, fecha, usuario_id)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         """;
 
         try (Connection cn = DataSourceFactory.getConnection()) {
@@ -76,12 +76,13 @@ public class JdbcMovimientoDao implements MovimientoDao {
                     ps.setString(2, m.getTipo().toUpperCase());
                     ps.setBigDecimal(3, m.getCantidad());
                     ps.setString(4, m.getDestinoFuente());
-                    ps.setTimestamp(5, Timestamp.valueOf(m.getFecha()));
+                    ps.setString(5, m.getSolicitante());
+                    ps.setTimestamp(6, Timestamp.valueOf(m.getFecha()));
 
                     if (m.getUsuario() != null && m.getUsuario().getId() != null) {
-                        ps.setLong(6, m.getUsuario().getId());
+                        ps.setLong(7, m.getUsuario().getId());
                     } else {
-                        ps.setNull(6, Types.BIGINT);
+                        ps.setNull(7, Types.BIGINT);
                     }
 
                     ps.executeUpdate();
@@ -113,7 +114,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
     @Override
     public List<Movimiento> ultimosPorInsumo(long insumoId, int limit) {
         final String sql = """
-            SELECT id, insumo_id, tipo, cantidad, destino_fuente, fecha, usuario_id
+            SELECT id, insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id
             FROM movimiento
             WHERE insumo_id = ?
             ORDER BY fecha DESC, id DESC
@@ -138,6 +139,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
                     BigDecimal cant = rs.getBigDecimal("cantidad");
                     m.setCantidad(cant == null ? BigDecimal.ZERO : cant);
                     m.setDestinoFuente(rs.getString("destino_fuente"));
+                    m.setSolicitante(rs.getString("solicitante"));
 
                     Timestamp ts = rs.getTimestamp("fecha");
                     if (ts != null) {
@@ -210,7 +212,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
     @Override
     public List<Movimiento> buscarPorFechaYTipo(LocalDateTime desde, LocalDateTime hasta, String tipo) {
         StringBuilder sql = new StringBuilder("""
-            SELECT m.id, m.insumo_id, m.tipo, m.cantidad, m.destino_fuente, m.fecha, m.usuario_id,
+            SELECT m.id, m.insumo_id, m.tipo, m.cantidad, m.destino_fuente, m.solicitante, m.fecha, m.usuario_id,
                    i.codigo, i.descripcion, i.ubicacion, i.tipo AS insumo_tipo, i.estado
             FROM movimiento m
             JOIN insumo i ON i.id = m.insumo_id
@@ -257,6 +259,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
                     BigDecimal cant = rs.getBigDecimal("cantidad");
                     m.setCantidad(cant == null ? BigDecimal.ZERO : cant);
                     m.setDestinoFuente(rs.getString("destino_fuente"));
+                    m.setSolicitante(rs.getString("solicitante"));
                     Timestamp ts = rs.getTimestamp("fecha");
                     if (ts != null) {
                         m.setFecha(ts.toLocalDateTime());

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcUbicacionDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcUbicacionDao.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +16,7 @@ public class JdbcUbicacionDao implements UbicacionDao {
 
     @Override
     public List<Ubicacion> listAll() {
-        final String sql = "SELECT id, nombre FROM ubicacion ORDER BY nombre";
+        final String sql = "SELECT id, nombre, activo FROM ubicacion WHERE activo = 1 ORDER BY nombre";
         try (Connection cn = DataSourceFactory.getConnection();
              PreparedStatement ps = cn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
@@ -24,11 +25,89 @@ public class JdbcUbicacionDao implements UbicacionDao {
                 Ubicacion u = new Ubicacion();
                 u.setId(rs.getInt("id"));
                 u.setNombre(rs.getString("nombre"));
+                u.setActiva(rs.getBoolean("activo"));
                 list.add(u);
             }
             return list;
         } catch (SQLException e) {
             throw new RuntimeException("Error listando ubicaciones", e);
+        }
+    }
+
+    @Override
+    public List<Ubicacion> listAllIncludingInactive() {
+        final String sql = "SELECT id, nombre, activo FROM ubicacion ORDER BY nombre";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            List<Ubicacion> list = new ArrayList<>();
+            while (rs.next()) {
+                Ubicacion u = new Ubicacion();
+                u.setId(rs.getInt("id"));
+                u.setNombre(rs.getString("nombre"));
+                u.setActiva(rs.getBoolean("activo"));
+                list.add(u);
+            }
+            return list;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error listando ubicaciones", e);
+        }
+    }
+
+    @Override
+    public Ubicacion create(Ubicacion ubicacion) {
+        final String sql = "INSERT INTO ubicacion(nombre, activo) VALUES(?, 1)";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, ubicacion.getNombre());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    ubicacion.setId(rs.getInt(1));
+                }
+            }
+            ubicacion.setActiva(true);
+            return ubicacion;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error creando ubicación", e);
+        }
+    }
+
+    @Override
+    public void update(Ubicacion ubicacion) {
+        final String sql = "UPDATE ubicacion SET nombre=?, activo=? WHERE id=?";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setString(1, ubicacion.getNombre());
+            ps.setBoolean(2, ubicacion.isActiva());
+            ps.setInt(3, ubicacion.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error actualizando ubicación id=" + ubicacion.getId(), e);
+        }
+    }
+
+    @Override
+    public void softDelete(int id) {
+        final String sql = "UPDATE ubicacion SET activo = 0 WHERE id = ?";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error dando de baja la ubicación id=" + id, e);
+        }
+    }
+
+    @Override
+    public void restore(int id) {
+        final String sql = "UPDATE ubicacion SET activo = 1 WHERE id = ?";
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error restaurando la ubicación id=" + id, e);
         }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/service/InventarioService.java
+++ b/src/main/java/ar/edu/unse/siga/service/InventarioService.java
@@ -41,9 +41,75 @@ public class InventarioService {
         return categoriaDao.findAllOrderByNombre();
     }
 
+    public List<Categoria> listarCategoriasIncluyendoInactivas() {
+        return categoriaDao.listAllIncludingInactive();
+    }
+
+    public Categoria crearCategoria(String nombre) {
+        if (nombre == null || nombre.isBlank()) {
+            throw new IllegalArgumentException("El nombre de la categoría es obligatorio");
+        }
+        Categoria c = new Categoria();
+        c.setNombre(nombre.trim());
+        categoriaDao.create(c);
+        return c;
+    }
+
+    public void actualizarCategoria(Categoria categoria) {
+        if (categoria == null || categoria.getId() <= 0) {
+            throw new IllegalArgumentException("Categoría inválida");
+        }
+        categoriaDao.update(categoria);
+    }
+
+    public void bajaLogicaCategoria(int id) {
+        categoriaDao.softDelete(id);
+    }
+
+    public void restaurarCategoria(int id) {
+        categoriaDao.restore(id);
+    }
+
     public List<Ubicacion> listarUbicaciones() {
         if (ubicacionDao == null) return java.util.List.of();
         return ubicacionDao.listAll();
+    }
+
+    public List<Ubicacion> listarUbicacionesIncluyendoInactivas() {
+        if (ubicacionDao == null) return java.util.List.of();
+        return ubicacionDao.listAllIncludingInactive();
+    }
+
+    public Ubicacion crearUbicacion(String nombre) {
+        if (ubicacionDao == null) {
+            throw new IllegalStateException("Gestión de ubicaciones no disponible");
+        }
+        if (nombre == null || nombre.isBlank()) {
+            throw new IllegalArgumentException("El nombre de la ubicación es obligatorio");
+        }
+        Ubicacion u = new Ubicacion();
+        u.setNombre(nombre.trim());
+        return ubicacionDao.create(u);
+    }
+
+    public void actualizarUbicacion(Ubicacion ubicacion) {
+        if (ubicacionDao == null) {
+            throw new IllegalStateException("Gestión de ubicaciones no disponible");
+        }
+        if (ubicacion == null || ubicacion.getId() == null) {
+            throw new IllegalArgumentException("Ubicación inválida");
+        }
+        ubicacionDao.update(ubicacion);
+    }
+
+    public void bajaLogicaUbicacion(int id) {
+        if (ubicacionDao == null) return;
+        ubicacionDao.softDelete(id);
+    }
+
+    public void restaurarUbicacion(int id) {
+        if (ubicacionDao == null) return;
+        ubicacionDao.restore(id);
     }
 
     // === Insumos ===
@@ -93,7 +159,11 @@ public class InventarioService {
     public List<Insumo> listarTodos() { return insumoDao.listAll(); }
 
     // === Movimientos ===
-    public Long registrarMovimiento(Long insumoId, String tipo, BigDecimal cantidad, String destinoFuente) {
+    public Long registrarMovimiento(Long insumoId,
+                                    String tipo,
+                                    BigDecimal cantidad,
+                                    String destinoFuente,
+                                    String solicitante) {
         if (insumoId == null) {
             throw new IllegalArgumentException("Insumo no especificado");
         }
@@ -129,11 +199,21 @@ public class InventarioService {
                     formatCantidad(stockActual), formatCantidad(qty)));
         }
 
+        String destino = destinoFuente == null ? "" : destinoFuente.trim();
+        String solicitanteNorm = solicitante == null ? "" : solicitante.trim();
+
+        if ("SALIDA".equalsIgnoreCase(tipoNorm)) {
+            if (solicitanteNorm.isBlank()) {
+                throw new IllegalArgumentException("Debe indicar el solicitante para registrar la salida.");
+            }
+        }
+
         Movimiento m = new Movimiento();
         m.setInsumo(insumo);
         m.setTipo(tipoNorm);
         m.setCantidad(qty);
-        m.setDestinoFuente(destinoFuente);
+        m.setDestinoFuente(destino);
+        m.setSolicitante(solicitanteNorm.isBlank() ? null : solicitanteNorm);
 
         Usuario u = CurrentSession.getUser();
         if (u != null) m.setUsuario(u);

--- a/src/main/java/ar/edu/unse/siga/ui/InventarioFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/InventarioFrame.java
@@ -135,11 +135,41 @@ public class InventarioFrame extends JFrame {
             if (row < 0) { JOptionPane.showMessageDialog(this, "Seleccioná un insumo"); return; }
             var sel = tableModel.getAt(row);
 
-            var dlg = new MovimientoDialog(this);
+            String[] opciones = {"ENTRADA", "SALIDA"};
+            String tipo = (String) JOptionPane.showInputDialog(
+                    this,
+                    "Seleccioná el tipo de movimiento",
+                    "Movimiento",
+                    JOptionPane.QUESTION_MESSAGE,
+                    null,
+                    opciones,
+                    "SALIDA");
+            if (tipo == null) return;
+
+            java.math.BigDecimal stockActual = java.math.BigDecimal.ZERO;
+            try {
+                var res = service.stockActual(sel.getId());
+                if (res != null) {
+                    stockActual = res.getStockActualDecimal();
+                }
+            } catch (Exception ignored) {}
+
+            String contexto = String.format("%s · %s  |  Stock actual: %s",
+                    sel.getCodigo(),
+                    sel.getDescripcion() == null ? "" : sel.getDescripcion(),
+                    stockActual.stripTrailingZeros().toPlainString());
+
+            boolean allowDecimal = sel.getTipo() == null || !"BIEN".equalsIgnoreCase(sel.getTipo());
+            java.util.List<String> ubicaciones = service.listarUbicaciones().stream()
+                    .map(u -> u.getNombre())
+                    .filter(s -> s != null && !s.isBlank())
+                    .collect(java.util.stream.Collectors.toList());
+
+            var dlg = new MovimientoDialog(this, contexto, tipo, allowDecimal, ubicaciones);
             dlg.setVisible(true);
             if (dlg.isAccepted()) {
                 try {
-                    service.registrarMovimiento(sel.getId(), dlg.getTipo(), dlg.getCantidad(), dlg.getDestinoFuente());
+                    service.registrarMovimiento(sel.getId(), dlg.getTipo(), dlg.getCantidad(), dlg.getDestinoFuente(), dlg.getSolicitante());
                     loadData();
                     JOptionPane.showMessageDialog(this, "Movimiento registrado");
                 } catch (Exception ex) {
@@ -157,14 +187,14 @@ public class InventarioFrame extends JFrame {
                 String f2 = sdf.format(d2) + " 23:59:59";
 
                 String sql = """
-                    SELECT m.id, i.codigo, i.descripcion, m.tipo, m.cantidad, m.destino_fuente, m.fecha
+                    SELECT m.id, i.codigo, i.descripcion, m.tipo, m.cantidad, m.destino_fuente, m.solicitante, m.fecha
                     FROM movimiento m JOIN insumo i ON i.id = m.insumo_id
                     WHERE m.fecha BETWEEN ? AND ?
                     ORDER BY m.fecha DESC
                 """;
 
                 java.util.List<String[]> rows = new java.util.ArrayList<>();
-                rows.add(new String[]{"ID","CODIGO","DESCRIPCION","TIPO","CANTIDAD","DESTINO_FUENTE","FECHA"});
+                rows.add(new String[]{"ID","CODIGO","DESCRIPCION","TIPO","CANTIDAD","DESTINO","SOLICITANTE","FECHA"});
 
                 try (var cn = getConnection(); var ps = cn.prepareStatement(sql)) {
                     ps.setString(1, f1);
@@ -178,6 +208,7 @@ public class InventarioFrame extends JFrame {
                                 rs.getString("tipo"),
                                 String.valueOf(rs.getInt("cantidad")),
                                 rs.getString("destino_fuente"),
+                                rs.getString("solicitante"),
                                 String.valueOf(rs.getTimestamp("fecha"))
                             });
                         }
@@ -216,7 +247,7 @@ public class InventarioFrame extends JFrame {
 
     private List<Categoria> loadCategorias() {
         List<Categoria> list = new ArrayList<>();
-        String sql = "SELECT id, nombre FROM categoria ORDER BY nombre";
+        String sql = "SELECT id, nombre FROM categoria WHERE activo = 1 ORDER BY nombre";
         try (Connection cn = getConnection();
              PreparedStatement ps = cn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {

--- a/src/main/java/ar/edu/unse/siga/ui/MainFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/MainFrame.java
@@ -7,6 +7,7 @@ import ar.edu.unse.siga.service.AuthService;
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.ui.base.ThemeManager;
+import ar.edu.unse.siga.ui.inventario.AjustesAvanzadosDialog;
 import ar.edu.unse.siga.ui.inventario.CategoriaFrame;
 import ar.edu.unse.siga.ui.inventario.InsumoFrame;
 import ar.edu.unse.siga.ui.reportes.ReporteMovimientosDialog;
@@ -55,6 +56,9 @@ public class MainFrame extends JFrame {
         var tb = new JToolBar();
         tb.setFloatable(false);
 
+        boolean isAdmin = CurrentSession.getUser() != null
+                && "ADMIN".equalsIgnoreCase(CurrentSession.getUser().getRol().getNombre());
+
         var btnIns = new JButton("Insumos", ThemeManager.svg("icons/add.svg", 16));
         btnIns.addActionListener(e -> openInDesktop(new ar.edu.unse.siga.ui.inventario.InsumoFrame(inventarioService)));
 
@@ -67,6 +71,12 @@ public class MainFrame extends JFrame {
         tb.add(btnIns);
         tb.add(btnTra);
         tb.add(btnCsv);
+
+        if (isAdmin) {
+            var btnAjustes = new JButton("Ajustes");
+            btnAjustes.addActionListener(e -> new AjustesAvanzadosDialog(this, inventarioService).setVisible(true));
+            tb.add(btnAjustes);
+        }
         return tb;
     }
 

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/AjustesAvanzadosDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/AjustesAvanzadosDialog.java
@@ -1,0 +1,272 @@
+package ar.edu.unse.siga.ui.inventario;
+
+import ar.edu.unse.siga.domain.Categoria;
+import ar.edu.unse.siga.domain.Ubicacion;
+import ar.edu.unse.siga.service.InventarioService;
+import ar.edu.unse.siga.ui.base.CrudTableModel;
+import ar.edu.unse.siga.ui.base.Ui;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+
+public class AjustesAvanzadosDialog extends JDialog {
+
+    private final InventarioService service;
+
+    private final CategoriaTableModel categoriaModel = new CategoriaTableModel();
+    private final UbicacionTableModel ubicacionModel = new UbicacionTableModel();
+
+    private final JTable tblCategorias = new JTable(categoriaModel);
+    private final JTable tblUbicaciones = new JTable(ubicacionModel);
+
+    public AjustesAvanzadosDialog(Window owner, InventarioService service) {
+        super(owner, "Ajustes avanzados", ModalityType.APPLICATION_MODAL);
+        this.service = service;
+
+        setLayout(new BorderLayout(12, 12));
+        setPreferredSize(new Dimension(640, 420));
+
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Categorías", buildCategoriasPanel());
+        tabs.addTab("Ubicaciones", buildUbicacionesPanel());
+        add(tabs, BorderLayout.CENTER);
+
+        JButton btnCerrar = new JButton("Cerrar");
+        btnCerrar.addActionListener(e -> dispose());
+        JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        south.setBorder(new EmptyBorder(0, 0, 12, 12));
+        south.add(btnCerrar);
+        add(south, BorderLayout.SOUTH);
+
+        loadCategorias();
+        loadUbicaciones();
+
+        pack();
+        setLocationRelativeTo(owner);
+    }
+
+    private JPanel buildCategoriasPanel() {
+        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+
+        tblCategorias.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        JScrollPane scroll = new JScrollPane(tblCategorias);
+        panel.add(scroll, BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        JButton btnNueva = new JButton("Nueva");
+        JButton btnRenombrar = new JButton("Renombrar");
+        JButton btnBaja = new JButton("Baja lógica");
+        JButton btnRestaurar = new JButton("Restaurar");
+
+        buttons.add(btnNueva);
+        buttons.add(btnRenombrar);
+        buttons.add(btnBaja);
+        buttons.add(btnRestaurar);
+        panel.add(buttons, BorderLayout.NORTH);
+
+        btnNueva.addActionListener(e -> onNuevaCategoria());
+        btnRenombrar.addActionListener(e -> onRenombrarCategoria());
+        btnBaja.addActionListener(e -> onBajaCategoria());
+        btnRestaurar.addActionListener(e -> onRestaurarCategoria());
+
+        return panel;
+    }
+
+    private JPanel buildUbicacionesPanel() {
+        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+
+        tblUbicaciones.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        JScrollPane scroll = new JScrollPane(tblUbicaciones);
+        panel.add(scroll, BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        JButton btnNueva = new JButton("Nueva");
+        JButton btnRenombrar = new JButton("Renombrar");
+        JButton btnBaja = new JButton("Baja lógica");
+        JButton btnRestaurar = new JButton("Restaurar");
+
+        buttons.add(btnNueva);
+        buttons.add(btnRenombrar);
+        buttons.add(btnBaja);
+        buttons.add(btnRestaurar);
+        panel.add(buttons, BorderLayout.NORTH);
+
+        btnNueva.addActionListener(e -> onNuevaUbicacion());
+        btnRenombrar.addActionListener(e -> onRenombrarUbicacion());
+        btnBaja.addActionListener(e -> onBajaUbicacion());
+        btnRestaurar.addActionListener(e -> onRestaurarUbicacion());
+
+        return panel;
+    }
+
+    private void loadCategorias() {
+        try {
+            categoriaModel.setData(service.listarCategoriasIncluyendoInactivas());
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void loadUbicaciones() {
+        try {
+            ubicacionModel.setData(service.listarUbicacionesIncluyendoInactivas());
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onNuevaCategoria() {
+        String nombre = JOptionPane.showInputDialog(this, "Nombre de la categoría:");
+        if (nombre == null || nombre.isBlank()) return;
+        try {
+            service.crearCategoria(nombre);
+            loadCategorias();
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onRenombrarCategoria() {
+        int row = tblCategorias.getSelectedRow();
+        if (row < 0) { Ui.info(this, "Seleccioná una categoría"); return; }
+        Categoria sel = categoriaModel.getAt(row);
+        String nombre = JOptionPane.showInputDialog(this, "Nuevo nombre:", sel.getNombre());
+        if (nombre == null || nombre.isBlank()) return;
+        try {
+            sel.setNombre(nombre.trim());
+            service.actualizarCategoria(sel);
+            loadCategorias();
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onBajaCategoria() {
+        ejecutarSobreCategoria(sel -> {
+            if (!sel.isActiva()) {
+                Ui.info(this, "La categoría ya está dada de baja.");
+                return;
+            }
+            if (Ui.confirm(this, "¿Dar de baja la categoría '" + sel.getNombre() + "'?")) {
+                service.bajaLogicaCategoria(sel.getId());
+                loadCategorias();
+            }
+        });
+    }
+
+    private void onRestaurarCategoria() {
+        ejecutarSobreCategoria(sel -> {
+            if (sel.isActiva()) {
+                Ui.info(this, "La categoría ya está activa.");
+                return;
+            }
+            service.restaurarCategoria(sel.getId());
+            loadCategorias();
+        });
+    }
+
+    private void ejecutarSobreCategoria(java.util.function.Consumer<Categoria> action) {
+        int row = tblCategorias.getSelectedRow();
+        if (row < 0) { Ui.info(this, "Seleccioná una categoría"); return; }
+        Categoria sel = categoriaModel.getAt(row);
+        try {
+            action.accept(sel);
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onNuevaUbicacion() {
+        String nombre = JOptionPane.showInputDialog(this, "Nombre de la ubicación:");
+        if (nombre == null || nombre.isBlank()) return;
+        try {
+            service.crearUbicacion(nombre);
+            loadUbicaciones();
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onRenombrarUbicacion() {
+        int row = tblUbicaciones.getSelectedRow();
+        if (row < 0) { Ui.info(this, "Seleccioná una ubicación"); return; }
+        Ubicacion sel = ubicacionModel.getAt(row);
+        String nombre = JOptionPane.showInputDialog(this, "Nuevo nombre:", sel.getNombre());
+        if (nombre == null || nombre.isBlank()) return;
+        try {
+            sel.setNombre(nombre.trim());
+            service.actualizarUbicacion(sel);
+            loadUbicaciones();
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    private void onBajaUbicacion() {
+        ejecutarSobreUbicacion(sel -> {
+            if (!sel.isActiva()) {
+                Ui.info(this, "La ubicación ya está dada de baja.");
+                return;
+            }
+            if (Ui.confirm(this, "¿Dar de baja la ubicación '" + sel.getNombre() + "'?")) {
+                service.bajaLogicaUbicacion(sel.getId());
+                loadUbicaciones();
+            }
+        });
+    }
+
+    private void onRestaurarUbicacion() {
+        ejecutarSobreUbicacion(sel -> {
+            if (sel.isActiva()) {
+                Ui.info(this, "La ubicación ya está activa.");
+                return;
+            }
+            service.restaurarUbicacion(sel.getId());
+            loadUbicaciones();
+        });
+    }
+
+    private void ejecutarSobreUbicacion(java.util.function.Consumer<Ubicacion> action) {
+        int row = tblUbicaciones.getSelectedRow();
+        if (row < 0) { Ui.info(this, "Seleccioná una ubicación"); return; }
+        Ubicacion sel = ubicacionModel.getAt(row);
+        try {
+            action.accept(sel);
+        } catch (Exception e) {
+            Ui.error(this, e);
+        }
+    }
+
+    static class CategoriaTableModel extends CrudTableModel<Categoria> {
+        CategoriaTableModel() { super(new String[]{"ID", "Nombre", "Estado"}); }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            Categoria c = data.get(row);
+            return switch (col) {
+                case 0 -> c.getId();
+                case 1 -> c.getNombre();
+                case 2 -> c.isActiva() ? "Activa" : "Inactiva";
+                default -> "";
+            };
+        }
+    }
+
+    static class UbicacionTableModel extends CrudTableModel<Ubicacion> {
+        UbicacionTableModel() { super(new String[]{"ID", "Nombre", "Estado"}); }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            Ubicacion u = data.get(row);
+            return switch (col) {
+                case 0 -> u.getId();
+                case 1 -> u.getNombre();
+                case 2 -> u.isActiva() ? "Activa" : "Inactiva";
+                default -> "";
+            };
+        }
+    }
+}

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/CategoriaFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/CategoriaFrame.java
@@ -23,7 +23,7 @@ public class CategoriaFrame extends BaseCrudFrame<Categoria> {
 
     @Override protected void loadData() {
         try (var cn = DataSourceFactory.getConnection();
-             var ps = cn.prepareStatement("SELECT id,nombre FROM categoria ORDER BY nombre");
+             var ps = cn.prepareStatement("SELECT id,nombre FROM categoria WHERE activo = 1 ORDER BY nombre");
              var rs = ps.executeQuery()) {
             List<Categoria> list = new ArrayList<>();
             while (rs.next()) list.add(new Categoria(rs.getInt("id"), rs.getString("nombre")));

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/InsumoFormDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/InsumoFormDialog.java
@@ -59,7 +59,7 @@ public class InsumoFormDialog extends JDialog {
 
     private void loadCategorias() {
         List<Categoria> list = new ArrayList<>();
-        String sql="SELECT id, nombre FROM categoria ORDER BY nombre";
+        String sql="SELECT id, nombre FROM categoria WHERE activo = 1 ORDER BY nombre";
         try (var cn = DataSourceFactory.getConnection();
              var ps = cn.prepareStatement(sql);
              var rs = ps.executeQuery()) {

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/InsumoFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/InsumoFrame.java
@@ -169,11 +169,46 @@ public class InsumoFrame extends BaseCrudFrame<Insumo> {
     private void onMovimiento() {
         int r = selectedRowOrWarn(); if (r < 0) return;
         var sel = model.getAt(r);
-        var dlg = new MovimientoDialog(SwingUtilities.getWindowAncestor(this));
+        String[] opciones = {"ENTRADA", "SALIDA"};
+        String tipo = (String) JOptionPane.showInputDialog(
+                this,
+                "Seleccioná el tipo de movimiento",
+                "Movimiento",
+                JOptionPane.QUESTION_MESSAGE,
+                null,
+                opciones,
+                "SALIDA");
+        if (tipo == null) return;
+
+        java.math.BigDecimal stockActual = java.math.BigDecimal.ZERO;
+        try {
+            var res = service.stockActual(sel.getId());
+            if (res != null) {
+                stockActual = res.getStockActualDecimal();
+            }
+        } catch (Exception ignored) {}
+
+        String contexto = String.format("%s · %s  |  Stock actual: %s",
+                sel.getCodigo(),
+                sel.getDescripcion() == null ? "" : sel.getDescripcion(),
+                stockActual.stripTrailingZeros().toPlainString());
+
+        boolean allowDecimal = sel.getTipo() == null || !"BIEN".equalsIgnoreCase(sel.getTipo());
+        java.util.List<String> ubicaciones = service.listarUbicaciones().stream()
+                .map(u -> u.getNombre())
+                .filter(s -> s != null && !s.isBlank())
+                .collect(java.util.stream.Collectors.toList());
+
+        var dlg = new MovimientoDialog(
+                SwingUtilities.getWindowAncestor(this),
+                contexto,
+                tipo,
+                allowDecimal,
+                ubicaciones);
         dlg.setVisible(true);
         if (dlg.isAccepted()) {
             try {
-                service.registrarMovimiento(sel.getId(), dlg.getTipo(), dlg.getCantidad(), dlg.getDestinoFuente());
+                service.registrarMovimiento(sel.getId(), dlg.getTipo(), dlg.getCantidad(), dlg.getDestinoFuente(), dlg.getSolicitante());
                 Ui.info(this, "Movimiento registrado");
                 loadData();
             } catch (Exception e) { Ui.error(this, e); }

--- a/src/main/java/ar/edu/unse/siga/ui/inventario/MovimientoDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/inventario/MovimientoDialog.java
@@ -14,10 +14,15 @@ public class MovimientoDialog extends JDialog {
     private final JLabel lblTipo = new JLabel();
     private final JTextField txtCantidad = new JTextField();
     private final JComboBox<String> cbDestino = new JComboBox<>();
+    private final JTextField txtSolicitante = new JTextField();
 
     private final String tipoMovimiento;
     private final boolean allowDecimal;
     private boolean accepted = false;
+
+    public MovimientoDialog(Window owner) {
+        this(owner, null, "SALIDA", true, java.util.List.of());
+    }
 
     public MovimientoDialog(Window owner,
                             String contexto,
@@ -76,6 +81,18 @@ public class MovimientoDialog extends JDialog {
             if (ubicaciones != null && !ubicaciones.isEmpty()) {
                 ubicaciones.forEach(cbDestino::addItem);
             }
+
+            gc.gridx = 0;
+            gc.gridy++;
+            gc.weightx = 0;
+            gc.fill = GridBagConstraints.NONE;
+            panel.add(label("Solicitante"), gc);
+
+            gc.gridx = 1;
+            gc.fill = GridBagConstraints.HORIZONTAL;
+            gc.weightx = 1;
+            txtSolicitante.putClientProperty("JTextField.placeholderText", "Persona que retira");
+            panel.add(txtSolicitante, gc);
         }
 
         add(panel, BorderLayout.CENTER);
@@ -125,6 +142,13 @@ public class MovimientoDialog extends JDialog {
                 JOptionPane.showMessageDialog(this, "La cantidad debe ser un entero.", "Atención", JOptionPane.WARNING_MESSAGE);
                 return false;
             }
+            if (esSalida()) {
+                String solicitante = getSolicitante();
+                if (solicitante.isBlank()) {
+                    JOptionPane.showMessageDialog(this, "Indicá el solicitante al registrar la salida.", "Atención", JOptionPane.WARNING_MESSAGE);
+                    return false;
+                }
+            }
             return true;
         } catch (IllegalArgumentException ex) {
             JOptionPane.showMessageDialog(this, ex.getMessage(), "Atención", JOptionPane.WARNING_MESSAGE);
@@ -159,5 +183,9 @@ public class MovimientoDialog extends JDialog {
         }
         Object sel = cbDestino.getSelectedItem();
         return sel == null ? "" : sel.toString();
+    }
+
+    public String getSolicitante() {
+        return txtSolicitante.getText() == null ? "" : txtSolicitante.getText().trim();
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
@@ -287,6 +287,7 @@ public class InventoryMovementsPage extends JPanel {
 
         BigDecimal cantidad = dlg.getCantidad();
         String destino = dlg.getDestinoFuente();
+        String solicitante = dlg.getSolicitante();
 
         if (cantidad.compareTo(BigDecimal.ZERO) <= 0) {
             JOptionPane.showMessageDialog(this, "La cantidad debe ser mayor a 0.", "Atención", JOptionPane.WARNING_MESSAGE);
@@ -294,7 +295,7 @@ public class InventoryMovementsPage extends JPanel {
         }
 
         try {
-            service.registrarMovimiento(sel.getId(), tipoInicial, cantidad, destino);
+            service.registrarMovimiento(sel.getId(), tipoInicial, cantidad, destino, solicitante);
 
             StockCheckResult res = service.stockActual(sel.getId());
             BigDecimal nuevoStock = res == null ? BigDecimal.ZERO : res.getStockActualDecimal();
@@ -332,9 +333,10 @@ public class InventoryMovementsPage extends JPanel {
             for (Movimiento m : movs) {
                 String fecha = (m.getFecha() != null ? m.getFecha().format(fmt) : "");
                 String cantidad = formatCantidad(m.getCantidad());
-                String linea = String.format("%s · x%s %s · Destino: %s",
-                        fecha, cantidad, m.getTipo(),
-                        (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank()) ? "-" : m.getDestinoFuente());
+                String destino = (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank()) ? "-" : m.getDestinoFuente();
+                String solicitante = (m.getSolicitante() == null || m.getSolicitante().isBlank()) ? "-" : m.getSolicitante();
+                String linea = String.format("%s · x%s %s · Destino: %s · Solicitante: %s",
+                        fecha, cantidad, m.getTipo(), destino, solicitante);
                 historialModel.addElement(linea);
             }
         } catch (Exception ex) {

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -40,7 +40,7 @@ public class TramiteEntradaPage extends JPanel {
 
     // --- Campos de Registro ---
     private final JTextField txtAsunto = new JTextField(25);
-    private final JTextField txtRemitente = new JTextField(25);
+    private final JTextField txtSolicitante = new JTextField(25);
     private final JTextArea  txtDescripcion = new JTextArea(4, 25);
     private final JTextField txtDestino = new JTextField(25);
     private final JLabel     lblNumero = new JLabel();
@@ -224,7 +224,7 @@ public class TramiteEntradaPage extends JPanel {
         form.add(Box.createVerticalStrut(16));
         form.add(field("Asunto", txtAsunto));
         form.add(Box.createVerticalStrut(14));
-        form.add(field("Remitente", txtRemitente));
+        form.add(field("Solicitante", txtSolicitante));
         form.add(Box.createVerticalStrut(14));
         txtDescripcion.setLineWrap(true);
         txtDescripcion.setWrapStyleWord(true);
@@ -404,7 +404,7 @@ private CardPanel recentTramitesCard() {
         try {
             String nro         = lblNumero.getText() != null ? lblNumero.getText().trim() : null;
             String asunto      = txtAsunto.getText() != null ? txtAsunto.getText().trim() : "";
-            String solicitante = txtRemitente.getText() != null ? txtRemitente.getText().trim() : "";
+            String solicitante = txtSolicitante.getText() != null ? txtSolicitante.getText().trim() : "";
             String descripcion = txtDescripcion.getText() != null ? txtDescripcion.getText().trim() : null;
             String destino     = txtDestino.getText() != null ? txtDestino.getText().trim() : "";
 
@@ -418,7 +418,7 @@ private CardPanel recentTramitesCard() {
             // Reset de campos
             lblNumero.setText(generateNumero(LocalDate.now()));
             txtAsunto.setText("");
-            txtRemitente.setText("");
+            txtSolicitante.setText("");
             txtDescripcion.setText("");
             txtDestino.setText("");
 

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -76,7 +76,7 @@ public class InformesPanel extends JPanel {
     private final JComboBox<String> filterEstado
             = new JComboBox<>(new String[]{"Todos", "Completado", "En proceso", "Pendiente"});
     private final DefaultTableModel modelTra = new DefaultTableModel(
-            new Object[]{"ID Trámite", "Asunto", "Fecha creación", "Última actualización", "Descripción", "Estado"}, 0
+            new Object[]{"ID Trámite", "Asunto", "Fecha creación", "Última actualización", "Descripción", "Solicitante", "Estado"}, 0
     ) {
         @Override
         public boolean isCellEditable(int r, int c) {
@@ -87,7 +87,7 @@ public class InformesPanel extends JPanel {
     // --- MOVIMIENTOS (similar a Trámites de UI) ---
     private final JTextField filterSearchMov = new JTextField(18);
     private final DefaultTableModel modelMov = new DefaultTableModel(
-            new Object[]{"Fecha", "Tipo", "Cantidad", "Código", "Descripción", "Ubicación", "Destino/Fuente"}, 0
+            new Object[]{"Fecha", "Tipo", "Cantidad", "Código", "Descripción", "Ubicación", "Destino", "Solicitante"}, 0
     ) {
         @Override
         public boolean isCellEditable(int r, int c) {
@@ -696,20 +696,21 @@ public class InformesPanel extends JPanel {
 
         // Anchos
         TableColumnModel tcm = table.getColumnModel();
-        if (tcm.getColumnCount() >= 6) {
+        if (tcm.getColumnCount() >= 7) {
             tcm.getColumn(0).setPreferredWidth(120);
             tcm.getColumn(1).setPreferredWidth(240);
             tcm.getColumn(2).setPreferredWidth(160);
             tcm.getColumn(3).setPreferredWidth(170);
             tcm.getColumn(4).setPreferredWidth(300);
-            tcm.getColumn(5).setPreferredWidth(130);
+            tcm.getColumn(5).setPreferredWidth(180);
+            tcm.getColumn(6).setPreferredWidth(130);
         }
 
         JTableHeader header = table.getTableHeader();
         header.setPreferredSize(new Dimension(header.getPreferredSize().width, 46));
         header.setDefaultRenderer(new TableHeaderRenderer());
 
-        table.getColumnModel().getColumn(5).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.STATUS));
+        table.getColumnModel().getColumn(6).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.STATUS));
 
         // Zebra para el resto
         DefaultTableCellRenderer zebra = new DefaultTableCellRenderer() {
@@ -777,8 +778,9 @@ public class InformesPanel extends JPanel {
                 String actualizacion = t.getFecha() == null ? "-" : t.getFecha().format(fmt);
                 String ultima = t.getFecha() == null ? "-" : t.getFecha().plusDays(1).format(fmt); // placeholder
                 String descripcion = extraerDescripcionTramite(t);
+                String solicitante = (t.getSolicitante() == null || t.getSolicitante().isBlank()) ? "-" : t.getSolicitante();
 
-                modelTra.addRow(new Object[]{t.getNro(), t.getAsunto(), actualizacion, ultima, descripcion, estado});
+                modelTra.addRow(new Object[]{t.getNro(), t.getAsunto(), actualizacion, ultima, descripcion, solicitante, estado});
             }
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -976,6 +978,7 @@ public class InformesPanel extends JPanel {
             tcm.getColumn(4).setPreferredWidth(220); // Descripción
             tcm.getColumn(5).setPreferredWidth(160); // Ubicación
             tcm.getColumn(6).setPreferredWidth(200); // Destino
+            tcm.getColumn(7).setPreferredWidth(180); // Solicitante
         }
 
         JTableHeader header = table.getTableHeader();
@@ -1057,9 +1060,13 @@ public class InformesPanel extends JPanel {
                         && !m.getInsumo().getUbicacion().isBlank())
                         ? m.getInsumo().getUbicacion() : "-";
 
+                String solicitante = (m.getSolicitante() == null || m.getSolicitante().isBlank())
+                        ? "-" : m.getSolicitante();
+
                 if (!search.isEmpty()) {
                     String src = (codigo + " " + desc + " " + ubic
-                            + " " + (m.getDestinoFuente() == null ? "" : m.getDestinoFuente()))
+                            + " " + (m.getDestinoFuente() == null ? "" : m.getDestinoFuente())
+                            + " " + solicitante)
                             .toLowerCase();
                     if (!src.contains(search)) {
                         continue;
@@ -1071,7 +1078,7 @@ public class InformesPanel extends JPanel {
                 String destino = (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank())
                         ? "-" : m.getDestinoFuente();
 
-                modelMov.addRow(new Object[]{fecha, m.getTipo(), cantidad, codigo, desc, ubic, destino});
+                modelMov.addRow(new Object[]{fecha, m.getTipo(), cantidad, codigo, desc, ubic, destino, solicitante});
             }
 
         } catch (Exception ex) {
@@ -1242,7 +1249,7 @@ public class InformesPanel extends JPanel {
         // Llamada con la firma correcta: usamos el filtro como "categoriaFiltro" (se mostrará como “Movimiento”)
         exportModelToPdf(
                 "INFORME DE MOVIMIENTOS",
-                new String[]{"Código", "Descripción", "Ubicación", "Entradas", "Salidas", "Stock Actual", "Fecha"},
+                new String[]{"Fecha", "Tipo", "Cantidad", "Código", "Descripción", "Ubicación", "Destino", "Solicitante"},
                 modelMov,
                 filtroTipo,
                 null,
@@ -1457,12 +1464,12 @@ public class InformesPanel extends JPanel {
                     pIns.setSpacingAfter(2f);
                     doc.add(pIns);
 
-                    PdfPTable tMov = new PdfPTable(4);
+                    PdfPTable tMov = new PdfPTable(5);
                     tMov.setWidthPercentage(100);
-                    tMov.setWidths(new float[]{1.2f, 0.8f, 0.6f, 1.4f});
+                    tMov.setWidths(new float[]{1.2f, 0.8f, 0.6f, 1.2f, 1.2f});
 
                     // header
-                    for (String h : List.of("Fecha", "Tipo", "Cantidad", "Destino/Fuente")) {
+                    for (String h : List.of("Fecha", "Tipo", "Cantidad", "Destino", "Solicitante")) {
                         PdfPCell hc = new PdfPCell(new Phrase(h, fHeader));
                         hc.setHorizontalAlignment(Element.ALIGN_CENTER);
                         hc.setBackgroundColor(BRAND);
@@ -1476,6 +1483,7 @@ public class InformesPanel extends JPanel {
                         String tipo = Objects.toString(m.getTipo(), "");
                         String cant = String.valueOf(m.getCantidad() == null ? 0 : m.getCantidad());
                         String dest = (m.getDestinoFuente() == null || m.getDestinoFuente().isBlank()) ? "-" : m.getDestinoFuente();
+                        String sol = (m.getSolicitante() == null || m.getSolicitante().isBlank()) ? "-" : m.getSolicitante();
 
                         PdfPCell c1 = new PdfPCell(new Phrase(f, fCell2));
                         c1.setHorizontalAlignment(Element.ALIGN_CENTER);
@@ -1496,6 +1504,11 @@ public class InformesPanel extends JPanel {
                         c4.setHorizontalAlignment(Element.ALIGN_LEFT);
                         c4.setPadding(4f);
                         tMov.addCell(c4);
+
+                        PdfPCell c5 = new PdfPCell(new Phrase(sol, fCell2));
+                        c5.setHorizontalAlignment(Element.ALIGN_LEFT);
+                        c5.setPadding(4f);
+                        tMov.addCell(c5);
                     }
 
                     doc.add(tMov);


### PR DESCRIPTION
## Summary
- add migration to flag categorias and ubicaciones as active/inactive and persist solicitante for movimientos
- expose advanced ajustes dialog so admins can create, rename, deactivate, and restore categorias y ubicaciones
- update movimiento flow to ask for solicitante/destino, enforce it in the service/DAO layer, and surface the data across inventory UI and reports
- rename trámite UI field Remitente to Solicitante and include the solicitante in informes de trámites

## Testing
- `mvn -q -DskipTests compile` *(fails: Unable to download org.junit:junit-bom:5.11.0 due to 403 from Maven Central)*


------
https://chatgpt.com/codex/tasks/task_e_68facf9398a883218701d0f3261aafc1