### PR TITLE
Fix database schema to support destino fields

### DIFF
--- a/db/migrations/00_schema.sql
+++ b/db/migrations/00_schema.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS tramite (
   solicitante  VARCHAR(100)  NULL,
   asunto       VARCHAR(150)  NULL,                          -- << requerido por DAO/pantallas
   descripcion  VARCHAR(255)  NULL,                          -- << requerido por DAO/pantallas
+  destino      VARCHAR(150)  NULL,                          -- << requerido por DAO/pantallas
   observacion  VARCHAR(255)  NULL,
   usuario_id   INT           NULL,
   PRIMARY KEY (id),
@@ -106,6 +107,7 @@ CREATE TABLE IF NOT EXISTS movimiento (
   tipo         VARCHAR(20)  NOT NULL,                       -- ENTRADA|SALIDA
   cantidad     DECIMAL(12,3) NOT NULL,
   fecha        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  destino_fuente VARCHAR(150) NULL,                         -- destino (salida) o fuente (entrada)
   solicitante  VARCHAR(100) NULL,
   observacion  VARCHAR(255) NULL,
   activo       TINYINT(1)   NOT NULL DEFAULT 1,

--- a/db/migrations/01_seed.sql
+++ b/db/migrations/01_seed.sql
@@ -27,6 +27,11 @@ WHERE c.nombre='Genérica' AND u.nombre='Depósito Principal'
 
 -- Movimiento semilla (sin usuario para evitar FK si todavía no existe admin)
 SET @insumo_id := (SELECT id FROM insumo WHERE codigo='SKU-000001' LIMIT 1);
-INSERT INTO movimiento (insumo_id, tipo, cantidad, fecha, solicitante, observacion, activo, estado, usuario_id, tramite_id)
-SELECT @insumo_id, 'ENTRADA', 3.000, NOW(), 'Usuario Demo', 'Alta inicial', 1, 'CONFIRMADO', NULL, NULL
+INSERT INTO movimiento (
+  insumo_id, tipo, cantidad, fecha,
+  destino_fuente, solicitante, observacion,
+  activo, estado, usuario_id, tramite_id)
+SELECT @insumo_id, 'ENTRADA', 3.000, NOW(),
+       'Stock inicial', 'Usuario Demo', 'Alta inicial',
+       1, 'CONFIRMADO', NULL, NULL
 WHERE @insumo_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- add the missing destino column to the tramite table definition so DAO queries can persist destinations
- extend the movimiento table with destino_fuente and seed initial data accordingly to match application expectations

## Testing
- mvn -q test *(fails: unable to download org.junit:junit-bom due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ff03f5f44c83218de516ccdb229f3b