### PR TITLE
feat: registrar trámites con salida de insumos

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Build:
 
 NetBeans → Clean and Build (o mvn -DskipTests=true clean package)
 
+**Nota:** La ejecución de `mvn test` requiere descargar dependencias de Maven Central. Si el entorno no tiene acceso a Internet, la tarea falla con error HTTP 403.
+
 Crear admin (una vez):
 
 Run ar.edu.unse.siga.tools.CreateAdminUser (crea admin/admin123)

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.2.224</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- MySQL JDBC -->
     <dependency>
       <groupId>com.mysql</groupId>

--- a/src/main/java/ar/edu/unse/siga/config/AppServices.java
+++ b/src/main/java/ar/edu/unse/siga/config/AppServices.java
@@ -4,11 +4,13 @@ import ar.edu.unse.siga.persistence.dao.CategoriaDao;
 import ar.edu.unse.siga.persistence.dao.InsumoDao;
 import ar.edu.unse.siga.persistence.dao.MovimientoDao;
 import ar.edu.unse.siga.persistence.dao.TramiteDao;
+import ar.edu.unse.siga.persistence.dao.TramiteDetalleDao;
 import ar.edu.unse.siga.persistence.dao.UbicacionDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcInsumoDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcMovimientoDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcCategoriaDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcTramiteDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcTramiteDetalleDao;
 import ar.edu.unse.siga.persistence.jdbc.JdbcUbicacionDao;
 
 import ar.edu.unse.siga.service.InventarioService;
@@ -28,11 +30,12 @@ public final class AppServices {
         CategoriaDao categoriaDao = new JdbcCategoriaDao();
         UbicacionDao ubicacionDao = new JdbcUbicacionDao();
         TramiteDao tramDao = new JdbcTramiteDao();
+        TramiteDetalleDao tramiteDetalleDao = new JdbcTramiteDetalleDao();
 
 
         // Services (constructor con las dependencias que usa)
         inventarioService = new InventarioService(insumoDao, movDao, categoriaDao, ubicacionDao);
-        tramiteService    = new TramiteService(tramDao);
+        tramiteService    = new TramiteService(tramDao, tramiteDetalleDao, movDao, insumoDao);
         
         
          

--- a/src/main/java/ar/edu/unse/siga/domain/Insumo.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Insumo.java
@@ -1,5 +1,6 @@
 package ar.edu.unse.siga.domain;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -15,6 +16,7 @@ public class Insumo {
     private String tipo;             // INSUMO / BIEN
     private Instant createdAt;       // timestamp de creación (BD)
     private LocalDate fechaAlta;     // vista amigable para informes
+    private BigDecimal stockActual;  // cacheado (opcional) para pantallas específicas
 
     public Insumo() {}
 
@@ -48,6 +50,9 @@ public class Insumo {
     /** Fecha de alta “linda” para UI/Informes (derivada de BD). */
     public LocalDate getFechaAlta() { return fechaAlta; }
     public void setFechaAlta(LocalDate fechaAlta) { this.fechaAlta = fechaAlta; }
+
+    public BigDecimal getStockActual() { return stockActual; }
+    public void setStockActual(BigDecimal stockActual) { this.stockActual = stockActual; }
 
     @Override public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
+++ b/src/main/java/ar/edu/unse/siga/domain/Movimiento.java
@@ -16,6 +16,7 @@ public class Movimiento {
     private String solicitante;
     private LocalDateTime fecha;
     private Usuario usuario;
+    private Long tramiteId;
 
     public Movimiento() {}
 
@@ -35,6 +36,9 @@ public class Movimiento {
     public void setFecha(LocalDateTime fecha) { this.fecha = fecha; }
     public Usuario getUsuario() { return usuario; }
     public void setUsuario(Usuario usuario) { this.usuario = usuario; }
+
+    public Long getTramiteId() { return tramiteId; }
+    public void setTramiteId(Long tramiteId) { this.tramiteId = tramiteId; }
 
     @Override public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/ar/edu/unse/siga/domain/TramiteDetalle.java
+++ b/src/main/java/ar/edu/unse/siga/domain/TramiteDetalle.java
@@ -1,0 +1,41 @@
+package ar.edu.unse.siga.domain;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class TramiteDetalle {
+
+    private Long id;
+    private Long tramiteId;
+    private Insumo insumo;
+    private BigDecimal cantidad;
+    private String observacion;
+
+    public TramiteDetalle() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getTramiteId() { return tramiteId; }
+    public void setTramiteId(Long tramiteId) { this.tramiteId = tramiteId; }
+
+    public Insumo getInsumo() { return insumo; }
+    public void setInsumo(Insumo insumo) { this.insumo = insumo; }
+
+    public BigDecimal getCantidad() { return cantidad; }
+    public void setCantidad(BigDecimal cantidad) { this.cantidad = cantidad; }
+
+    public String getObservacion() { return observacion; }
+    public void setObservacion(String observacion) { this.observacion = observacion; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TramiteDetalle)) return false;
+        TramiteDetalle that = (TramiteDetalle) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(id); }
+}

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/InsumoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/InsumoDao.java
@@ -11,5 +11,9 @@ public interface InsumoDao {
     Optional<Insumo> findByCodigo(String codigo);
     Optional<Insumo> findById(Long id);
     List<Insumo> listAll();
+
+    List<Insumo> listActivosConStock();
+
+    boolean decrementStock(java.sql.Connection cn, long insumoId, java.math.BigDecimal cantidad) throws java.sql.SQLException;
 }
 

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/MovimientoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/MovimientoDao.java
@@ -7,6 +7,12 @@ public interface MovimientoDao {
 
     Long registrar(Movimiento movimiento);
 
+    Long registrarSalida(java.sql.Connection cn,
+                         long insumoId,
+                         java.math.BigDecimal cantidad,
+                         String solicitante,
+                         Long tramiteId) throws java.sql.SQLException;
+
     // ya lo agregamos antes:
     java.util.List<Movimiento> ultimosPorInsumo(long insumoId, int limit);
 

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/TramiteDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/TramiteDao.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface TramiteDao {
     Long create(Tramite t);
+
+    Long create(Tramite t, java.sql.Connection cn) throws java.sql.SQLException;
     void updateEstado(Long id, String nuevoEstado);
     Optional<Tramite> findByNro(String nro);
     List<Tramite> listAll();

--- a/src/main/java/ar/edu/unse/siga/persistence/dao/TramiteDetalleDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/dao/TramiteDetalleDao.java
@@ -1,0 +1,11 @@
+package ar.edu.unse.siga.persistence.dao;
+
+import ar.edu.unse.siga.domain.TramiteDetalle;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface TramiteDetalleDao {
+
+    Long create(TramiteDetalle detalle, Connection cn) throws SQLException;
+}

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcInsumoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcInsumoDao.java
@@ -5,6 +5,7 @@ import ar.edu.unse.siga.domain.Insumo;
 import ar.edu.unse.siga.persistence.DataSourceFactory;
 import ar.edu.unse.siga.persistence.dao.InsumoDao;
 
+import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +43,13 @@ public class JdbcInsumoDao implements InsumoDao {
         Date fa = safeGetDate(rs, "fecha_alta");
         if (fa != null) {
             i.setFechaAlta(fa.toLocalDate());
+        }
+
+        try {
+            BigDecimal stock = rs.getBigDecimal("stock_actual");
+            i.setStockActual(stock);
+        } catch (SQLException ignore) {
+            i.setStockActual(null);
         }
 
         return i;
@@ -200,6 +208,68 @@ public class JdbcInsumoDao implements InsumoDao {
 
         } catch (SQLException e) {
             throw new RuntimeException("Error listando insumos", e);
+        }
+    }
+
+    @Override
+    public List<Insumo> listActivosConStock() {
+        final String sql = """
+            SELECT i.*, c.nombre AS categoria_nombre,
+                   COALESCE(SUM(CASE WHEN m.tipo = 'ENTRADA' THEN m.cantidad ELSE -m.cantidad END), 0) AS stock_actual
+            FROM insumo i
+            JOIN categoria c ON c.id = i.categoria_id
+            LEFT JOIN movimiento m ON m.insumo_id = i.id
+            WHERE UPPER(i.estado) = 'ACTIVO'
+            GROUP BY i.id, i.codigo, i.descripcion, i.categoria_id, i.stock_minimo, i.ubicacion, i.estado, i.tipo,
+                     i.created_at, i.fecha_alta, c.nombre
+            HAVING stock_actual > 0
+            ORDER BY i.descripcion
+        """;
+
+        try (Connection cn = DataSourceFactory.getConnection();
+             PreparedStatement ps = cn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+
+            List<Insumo> list = new ArrayList<>();
+            while (rs.next()) {
+                list.add(mapRow(rs));
+            }
+            return list;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error listando insumos con stock", e);
+        }
+    }
+
+    @Override
+    public boolean decrementStock(Connection cn, long insumoId, BigDecimal cantidad) throws SQLException {
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Cantidad inválida para descontar stock");
+        }
+
+        final String sql = """
+            UPDATE insumo
+            SET stock = (
+                    SELECT COALESCE(SUM(CASE WHEN tipo = 'ENTRADA' THEN cantidad ELSE -cantidad END), 0)
+                    FROM movimiento
+                    WHERE insumo_id = ?
+                ) - ?
+            WHERE id = ?
+              AND (
+                    SELECT COALESCE(SUM(CASE WHEN tipo = 'ENTRADA' THEN cantidad ELSE -cantidad END), 0)
+                    FROM movimiento
+                    WHERE insumo_id = ?
+                ) >= ?
+        """;
+
+        try (PreparedStatement ps = cn.prepareStatement(sql)) {
+            ps.setLong(1, insumoId);
+            ps.setBigDecimal(2, cantidad);
+            ps.setLong(3, insumoId);
+            ps.setLong(4, insumoId);
+            ps.setBigDecimal(5, cantidad);
+
+            int updated = ps.executeUpdate();
+            return updated == 1;
         }
     }
 

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcMovimientoDao.java
@@ -17,6 +17,44 @@ public class JdbcMovimientoDao implements MovimientoDao {
     private static final String ENTRADA = "ENTRADA";
     private static final String SALIDA = "SALIDA";
 
+    private Long insertMovimiento(Connection cn, Movimiento m) throws SQLException {
+        final String insertSql = """
+            INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id, tramite_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        try (PreparedStatement ps = cn.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setLong(1, m.getInsumo().getId());
+            ps.setString(2, m.getTipo().toUpperCase());
+            ps.setBigDecimal(3, m.getCantidad());
+            ps.setString(4, m.getDestinoFuente());
+            ps.setString(5, m.getSolicitante());
+            ps.setTimestamp(6, Timestamp.valueOf(m.getFecha() != null ? m.getFecha() : LocalDateTime.now()));
+
+            if (m.getUsuario() != null && m.getUsuario().getId() != null) {
+                ps.setLong(7, m.getUsuario().getId());
+            } else {
+                ps.setNull(7, Types.BIGINT);
+            }
+
+            if (m.getTramiteId() != null) {
+                ps.setLong(8, m.getTramiteId());
+            } else {
+                ps.setNull(8, Types.BIGINT);
+            }
+
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    long id = rs.getLong(1);
+                    m.setId(id);
+                    return id;
+                }
+            }
+        }
+        throw new SQLException("No se pudo registrar el movimiento");
+    }
+
     private BigDecimal stockActual(Connection cn, long insumoId) throws SQLException {
         final String sql = """
                 SELECT COALESCE(SUM(CASE WHEN tipo='ENTRADA' THEN cantidad ELSE -cantidad END),0) AS stock
@@ -47,11 +85,6 @@ public class JdbcMovimientoDao implements MovimientoDao {
             throw new IllegalArgumentException("Tipo de movimiento inválido.");
         }
 
-        final String insertSql = """
-            INSERT INTO movimiento (insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        """;
-
         try (Connection cn = DataSourceFactory.getConnection()) {
             boolean originalAutoCommit = cn.getAutoCommit();
             try {
@@ -71,32 +104,9 @@ public class JdbcMovimientoDao implements MovimientoDao {
                     m.setFecha(LocalDateTime.now());
                 }
 
-                try (PreparedStatement ps = cn.prepareStatement(insertSql, Statement.RETURN_GENERATED_KEYS)) {
-                    ps.setLong(1, m.getInsumo().getId());
-                    ps.setString(2, m.getTipo().toUpperCase());
-                    ps.setBigDecimal(3, m.getCantidad());
-                    ps.setString(4, m.getDestinoFuente());
-                    ps.setString(5, m.getSolicitante());
-                    ps.setTimestamp(6, Timestamp.valueOf(m.getFecha()));
-
-                    if (m.getUsuario() != null && m.getUsuario().getId() != null) {
-                        ps.setLong(7, m.getUsuario().getId());
-                    } else {
-                        ps.setNull(7, Types.BIGINT);
-                    }
-
-                    ps.executeUpdate();
-                    try (ResultSet rs = ps.getGeneratedKeys()) {
-                        if (rs.next()) {
-                            long id = rs.getLong(1);
-                            cn.commit();
-                            return id;
-                        }
-                    }
-                }
-
-                cn.rollback();
-                throw new RuntimeException("No se pudo registrar el movimiento.");
+                Long id = insertMovimiento(cn, m);
+                cn.commit();
+                return id;
             } catch (SQLException e) {
                 try { cn.rollback(); } catch (SQLException ignored) {}
                 throw new RuntimeException("Error registrando movimiento", e);
@@ -114,7 +124,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
     @Override
     public List<Movimiento> ultimosPorInsumo(long insumoId, int limit) {
         final String sql = """
-            SELECT id, insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id
+            SELECT id, insumo_id, tipo, cantidad, destino_fuente, solicitante, fecha, usuario_id, tramite_id
             FROM movimiento
             WHERE insumo_id = ?
             ORDER BY fecha DESC, id DESC
@@ -151,6 +161,11 @@ public class JdbcMovimientoDao implements MovimientoDao {
                         Usuario u = new Usuario();
                         u.setId(uid);
                         m.setUsuario(u);
+                    }
+
+                    long tid = rs.getLong("tramite_id");
+                    if (!rs.wasNull()) {
+                        m.setTramiteId(tid);
                     }
 
                     lista.add(m);
@@ -212,7 +227,7 @@ public class JdbcMovimientoDao implements MovimientoDao {
     @Override
     public List<Movimiento> buscarPorFechaYTipo(LocalDateTime desde, LocalDateTime hasta, String tipo) {
         StringBuilder sql = new StringBuilder("""
-            SELECT m.id, m.insumo_id, m.tipo, m.cantidad, m.destino_fuente, m.solicitante, m.fecha, m.usuario_id,
+            SELECT m.id, m.insumo_id, m.tipo, m.cantidad, m.destino_fuente, m.solicitante, m.fecha, m.usuario_id, m.tramite_id,
                    i.codigo, i.descripcion, i.ubicacion, i.tipo AS insumo_tipo, i.estado
             FROM movimiento m
             JOIN insumo i ON i.id = m.insumo_id
@@ -272,6 +287,11 @@ public class JdbcMovimientoDao implements MovimientoDao {
                         m.setUsuario(u);
                     }
 
+                    long tramiteId = rs.getLong("tramite_id");
+                    if (!rs.wasNull()) {
+                        m.setTramiteId(tramiteId);
+                    }
+
                     Insumo ins = new Insumo();
                     ins.setId(rs.getLong("insumo_id"));
                     ins.setCodigo(rs.getString("codigo"));
@@ -288,5 +308,28 @@ public class JdbcMovimientoDao implements MovimientoDao {
             throw new RuntimeException("Error buscando movimientos", e);
         }
         return lista;
+    }
+
+    @Override
+    public Long registrarSalida(Connection cn, long insumoId, BigDecimal cantidad, String solicitante, Long tramiteId) throws SQLException {
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Cantidad inválida");
+        }
+
+        BigDecimal actual = stockActual(cn, insumoId);
+        if (cantidad.compareTo(actual) > 0) {
+            throw new IllegalStateException("Stock insuficiente para la salida");
+        }
+
+        Movimiento m = new Movimiento();
+        Insumo ins = new Insumo();
+        ins.setId(insumoId);
+        m.setInsumo(ins);
+        m.setTipo(SALIDA);
+        m.setCantidad(cantidad);
+        m.setSolicitante(solicitante);
+        m.setTramiteId(tramiteId);
+        m.setFecha(LocalDateTime.now());
+        return insertMovimiento(cn, m);
     }
 }

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDao.java
@@ -32,9 +32,17 @@ public class JdbcTramiteDao implements TramiteDao {
 
     @Override
     public Long create(Tramite t) {
+        try (Connection cn = DataSourceFactory.getConnection()) {
+            return create(t, cn);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error insertando trámite", e);
+        }
+    }
+
+    @Override
+    public Long create(Tramite t, Connection cn) throws SQLException {
         String sql = "INSERT INTO tramite"+"(nro, asunto, estado, fecha, solicitante, descripcion, destino) VALUES (?,?,?,?,?,?,?)";
-        try (Connection cn = DataSourceFactory.getConnection();
-             PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
 
             ps.setString(1, t.getNro());
             ps.setString(2, t.getAsunto());
@@ -53,10 +61,8 @@ public class JdbcTramiteDao implements TramiteDao {
                     return id;
                 }
             }
-            throw new SQLException("No se pudo obtener el ID generado para trámite");
-        } catch (SQLException e) {
-            throw new RuntimeException("Error insertando trámite", e);
         }
+        throw new SQLException("No se pudo obtener el ID generado para trámite");
     }
 
     @Override

--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDetalleDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDetalleDao.java
@@ -1,0 +1,50 @@
+package ar.edu.unse.siga.persistence.jdbc;
+
+import ar.edu.unse.siga.domain.TramiteDetalle;
+import ar.edu.unse.siga.persistence.dao.TramiteDetalleDao;
+
+import java.sql.*;
+
+public class JdbcTramiteDetalleDao implements TramiteDetalleDao {
+
+    @Override
+    public Long create(TramiteDetalle detalle, Connection cn) throws SQLException {
+        if (detalle == null) {
+            throw new IllegalArgumentException("Detalle inválido");
+        }
+        if (detalle.getTramiteId() == null) {
+            throw new IllegalArgumentException("Trámite requerido");
+        }
+        if (detalle.getInsumo() == null || detalle.getInsumo().getId() == null) {
+            throw new IllegalArgumentException("Insumo requerido");
+        }
+        if (detalle.getCantidad() == null || detalle.getCantidad().signum() <= 0) {
+            throw new IllegalArgumentException("Cantidad inválida");
+        }
+
+        final String sql = """
+            INSERT INTO tramite_detalle (tramite_id, insumo_id, cantidad, observacion)
+            VALUES (?, ?, ?, ?)
+        """;
+
+        try (PreparedStatement ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setLong(1, detalle.getTramiteId());
+            ps.setLong(2, detalle.getInsumo().getId());
+            ps.setBigDecimal(3, detalle.getCantidad());
+            if (detalle.getObservacion() == null || detalle.getObservacion().isBlank()) {
+                ps.setNull(4, Types.VARCHAR);
+            } else {
+                ps.setString(4, detalle.getObservacion());
+            }
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    long id = rs.getLong(1);
+                    detalle.setId(id);
+                    return id;
+                }
+            }
+        }
+        throw new SQLException("No se pudo generar el ID del detalle del trámite");
+    }
+}

--- a/src/main/java/ar/edu/unse/siga/service/TramiteService.java
+++ b/src/main/java/ar/edu/unse/siga/service/TramiteService.java
@@ -1,21 +1,43 @@
 package ar.edu.unse.siga.service;
 
+import ar.edu.unse.siga.domain.Insumo;
 import ar.edu.unse.siga.domain.Tramite;
+import ar.edu.unse.siga.domain.TramiteDetalle;
+import ar.edu.unse.siga.persistence.DataSourceFactory;
+import ar.edu.unse.siga.persistence.dao.InsumoDao;
+import ar.edu.unse.siga.persistence.dao.MovimientoDao;
 import ar.edu.unse.siga.persistence.dao.TramiteDao;
+import ar.edu.unse.siga.persistence.dao.TramiteDetalleDao;
 
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class TramiteService {
 
     private final TramiteDao tramiteDao;
+    private final TramiteDetalleDao tramiteDetalleDao;
+    private final MovimientoDao movimientoDao;
+    private final InsumoDao insumoDao;
+    private static final String SOLICITANTE_INFORMES = "Informes";
 
     public TramiteService(TramiteDao tramiteDao) {
+        this(tramiteDao, null, null, null);
+    }
+
+    public TramiteService(TramiteDao tramiteDao,
+                          TramiteDetalleDao tramiteDetalleDao,
+                          MovimientoDao movimientoDao,
+                          InsumoDao insumoDao) {
         this.tramiteDao = tramiteDao;
+        this.tramiteDetalleDao = tramiteDetalleDao;
+        this.movimientoDao = movimientoDao;
+        this.insumoDao = insumoDao;
     }
 
     public Long registrarTramite(String nro, String asunto, String solicitante, String descripcion, String destino) {
@@ -86,6 +108,100 @@ public java.util.List<Tramite> tramitesRecientes(int limit) {
     return tramiteDao.listRecientes(limit); // requiere Dao (paso 2)
 }
 
+
+    public List<Insumo> insumosConStockDisponible() {
+        if (insumoDao == null) {
+            throw new IllegalStateException("InsumoDao no configurado");
+        }
+        return insumoDao.listActivosConStock();
+    }
+
+    public Long registrarNuevoTramite(List<LineaTramite> lineas) {
+        if (movimientoDao == null || insumoDao == null || tramiteDetalleDao == null) {
+            throw new IllegalStateException("Dependencias no configuradas para registrar trámite con insumos");
+        }
+        if (lineas == null || lineas.isEmpty()) {
+            throw new IllegalArgumentException("Debe indicar al menos un insumo");
+        }
+
+        LinkedHashMap<Long, BigDecimal> porInsumo = new LinkedHashMap<>();
+        lineas.forEach(l -> {
+            if (l == null) {
+                throw new IllegalArgumentException("Línea inválida");
+            }
+            if (l.cantidad <= 0) {
+                throw new IllegalArgumentException("Cantidad inválida para insumo " + l.insumoId);
+            }
+            porInsumo.merge(l.insumoId, BigDecimal.valueOf(l.cantidad), BigDecimal::add);
+        });
+
+        try (Connection cn = DataSourceFactory.getConnection()) {
+            boolean originalAuto = cn.getAutoCommit();
+            try {
+                cn.setAutoCommit(false);
+
+                Tramite tramite = new Tramite();
+                tramite.setNro("");
+                tramite.setAsunto("Salida de insumos");
+                tramite.setSolicitante(SOLICITANTE_INFORMES);
+                tramite.setDescripcion("Trámite generado automáticamente para entrega de insumos.");
+                tramite.setDestino("Informes");
+                tramite.setEstado("NUEVO");
+                tramite.setFecha(LocalDateTime.now());
+                Long tramiteId = tramiteDao.create(tramite, cn);
+
+                for (var entry : porInsumo.entrySet()) {
+                    Long insumoId = entry.getKey();
+                    BigDecimal cantidad = entry.getValue();
+
+                    boolean updated = insumoDao.decrementStock(cn, insumoId, cantidad);
+                    if (!updated) {
+                        throw new IllegalStateException("El stock cambió. Revisá cantidades e intentá nuevamente.");
+                    }
+
+                    TramiteDetalle detalle = new TramiteDetalle();
+                    detalle.setTramiteId(tramiteId);
+                    Insumo ins = new Insumo();
+                    ins.setId(insumoId);
+                    detalle.setInsumo(ins);
+                    detalle.setCantidad(cantidad);
+                    tramiteDetalleDao.create(detalle, cn);
+
+                    try {
+                        movimientoDao.registrarSalida(cn, insumoId, cantidad, SOLICITANTE_INFORMES, tramiteId);
+                    } catch (IllegalStateException ex) {
+                        throw new IllegalStateException("El stock cambió. Revisá cantidades e intentá nuevamente.", ex);
+                    }
+                }
+
+                cn.commit();
+                return tramiteId;
+            } catch (Exception e) {
+                try { cn.rollback(); } catch (SQLException ignored) {}
+                if (e instanceof IllegalStateException) {
+                    throw e;
+                }
+                throw new RuntimeException("No se pudo registrar el trámite", e);
+            } finally {
+                try { cn.setAutoCommit(originalAuto); } catch (SQLException ignored) {}
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error registrando trámite", e);
+        }
+    }
+
+    public static class LineaTramite {
+        private final long insumoId;
+        private final int cantidad;
+
+        public LineaTramite(long insumoId, int cantidad) {
+            this.insumoId = insumoId;
+            this.cantidad = cantidad;
+        }
+
+        public long getInsumoId() { return insumoId; }
+        public int getCantidad() { return cantidad; }
+    }
 
     
     

--- a/src/main/java/ar/edu/unse/siga/ui/base/BaseCrudFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/base/BaseCrudFrame.java
@@ -9,6 +9,7 @@ public abstract class BaseCrudFrame<T> extends JInternalFrame {
     protected final JButton btnEditar = new JButton("Editar");
     protected final JButton btnBaja = new JButton("Baja / Eliminar");
     protected final JButton btnRefrescar = new JButton("Refrescar");
+    protected final JPanel actionsPanel;
 
     protected BaseCrudFrame(String title) {
         super(title, true, true, true, true);
@@ -16,7 +17,8 @@ public abstract class BaseCrudFrame<T> extends JInternalFrame {
         add(new JScrollPane(table), BorderLayout.CENTER);
 
         var top = new JPanel(new BorderLayout());
-        top.add(Ui.flowLeft(btnNuevo, btnEditar, btnBaja, btnRefrescar), BorderLayout.WEST);
+        actionsPanel = Ui.flowLeft(btnNuevo, btnEditar, btnBaja, btnRefrescar);
+        top.add(actionsPanel, BorderLayout.WEST);
         add(top, BorderLayout.NORTH);
 
         btnRefrescar.addActionListener(e -> loadData());

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
@@ -1,0 +1,292 @@
+package ar.edu.unse.siga.ui.tramites;
+
+import ar.edu.unse.siga.domain.Insumo;
+import ar.edu.unse.siga.service.TramiteService;
+import ar.edu.unse.siga.ui.base.Ui;
+
+import javax.swing.*;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellEditor;
+import java.awt.*;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RegistrarTramiteDialog extends JDialog {
+
+    private final TramiteService tramiteService;
+    private final JTable table = new JTable();
+    private final LineaTableModel model = new LineaTableModel();
+    private final JButton btnGuardar = new JButton("Guardar");
+    private final JLabel lblTotales = new JLabel("0 ítems · 0 unidades");
+    private boolean accepted = false;
+    private final List<Insumo> insumosDisponibles;
+    private final boolean ready;
+
+    public RegistrarTramiteDialog(Window owner, TramiteService tramiteService) {
+        super(owner, "Registrar trámite de salida", ModalityType.APPLICATION_MODAL);
+        this.tramiteService = tramiteService;
+        this.insumosDisponibles = new ArrayList<>(tramiteService.insumosConStockDisponible());
+        this.ready = !insumosDisponibles.isEmpty();
+
+        if (!ready) {
+            Ui.warn(owner, "No hay insumos con stock disponible.");
+            accepted = false;
+            dispose();
+            return;
+        }
+
+        setLayout(new BorderLayout(10, 10));
+        table.setModel(model);
+        table.setRowHeight(26);
+        table.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
+
+        table.getColumnModel().getColumn(0).setCellEditor(new InsumoCellEditor());
+        table.getColumnModel().getColumn(2).setCellEditor(new CantidadCellEditor());
+
+        add(new JScrollPane(table), BorderLayout.CENTER);
+
+        JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JButton btnAgregar = new JButton("Agregar fila");
+        JButton btnQuitar = new JButton("Quitar fila");
+        actions.add(btnAgregar);
+        actions.add(btnQuitar);
+        actions.add(lblTotales);
+
+        JPanel bottom = new JPanel(new BorderLayout());
+        bottom.add(actions, BorderLayout.WEST);
+        JPanel right = Ui.flowRight(new JButton("Cancelar"), btnGuardar);
+        bottom.add(right, BorderLayout.EAST);
+        add(bottom, BorderLayout.SOUTH);
+
+        ((JButton) right.getComponent(0)).addActionListener(e -> dispose());
+        btnGuardar.addActionListener(e -> onGuardar());
+        btnAgregar.addActionListener(e -> model.addEmptyRow());
+        btnQuitar.addActionListener(e -> model.removeSelected(table.getSelectedRow()));
+
+        model.addTableModelListener(new TableModelListener() {
+            @Override
+            public void tableChanged(TableModelEvent e) {
+                updateState();
+            }
+        });
+
+        model.addEmptyRow();
+        updateState();
+
+        setPreferredSize(new Dimension(720, 400));
+        pack();
+        setLocationRelativeTo(owner);
+    }
+
+    private void updateState() {
+        lblTotales.setText(model.totales());
+        btnGuardar.setEnabled(model.isValidRows());
+    }
+
+    private void onGuardar() {
+        if (!model.isValidRows()) {
+            Ui.warn(this, "Completá correctamente todas las filas.");
+            return;
+        }
+        List<TramiteService.LineaTramite> lineas = model.toLineas();
+        try {
+            Long id = tramiteService.registrarNuevoTramite(lineas);
+            Ui.info(this, "Trámite registrado. ID: " + id);
+            accepted = true;
+            dispose();
+        } catch (IllegalStateException ex) {
+            Ui.warn(this, ex.getMessage());
+        } catch (Exception ex) {
+            Ui.error(this, ex);
+        }
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    private int stockDisponible(Insumo insumo) {
+        if (insumo == null) return 0;
+        BigDecimal stock = insumo.getStockActual();
+        if (stock == null) return 0;
+        return stock.setScale(0, RoundingMode.FLOOR).intValue();
+    }
+
+    private class LineaTableModel extends AbstractTableModel {
+        private final String[] cols = {"Insumo", "Stock disponible", "Cantidad"};
+        private final List<Fila> filas = new ArrayList<>();
+
+        void addEmptyRow() {
+            Insumo insumo = insumosDisponibles.stream()
+                    .filter(i -> filas.stream().noneMatch(f -> f.insumo != null && f.insumo.getId().equals(i.getId())))
+                    .findFirst()
+                    .orElse(null);
+            if (insumo == null) {
+                Ui.warn(RegistrarTramiteDialog.this, "Ya agregaste todos los insumos disponibles.");
+                return;
+            }
+            filas.add(new Fila(insumo, 1));
+            fireTableRowsInserted(filas.size() - 1, filas.size() - 1);
+        }
+
+        void removeSelected(int row) {
+            if (row >= 0 && row < filas.size()) {
+                filas.remove(row);
+                fireTableRowsDeleted(row, row);
+            }
+        }
+
+        boolean isValidRows() {
+            if (filas.isEmpty()) return false;
+            for (Fila f : filas) {
+                if (f.insumo == null) return false;
+                int max = stockDisponible(f.insumo);
+                if (f.cantidad <= 0 || f.cantidad > max) return false;
+            }
+            return true;
+        }
+
+        String totales() {
+            int items = filas.size();
+            int unidades = filas.stream().mapToInt(f -> f.cantidad).sum();
+            return String.format("%d ítems · %d unidades", items, unidades);
+        }
+
+        List<TramiteService.LineaTramite> toLineas() {
+            List<TramiteService.LineaTramite> list = new ArrayList<>();
+            for (Fila f : filas) {
+                list.add(new TramiteService.LineaTramite(f.insumo.getId(), f.cantidad));
+            }
+            return list;
+        }
+
+        @Override
+        public int getRowCount() { return filas.size(); }
+
+        @Override
+        public int getColumnCount() { return cols.length; }
+
+        @Override
+        public String getColumnName(int column) { return cols[column]; }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            return switch (columnIndex) {
+                case 0 -> Insumo.class;
+                case 1, 2 -> Integer.class;
+                default -> Object.class;
+            };
+        }
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return columnIndex != 1;
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            Fila f = filas.get(rowIndex);
+            return switch (columnIndex) {
+                case 0 -> f.insumo;
+                case 1 -> stockDisponible(f.insumo);
+                case 2 -> f.cantidad;
+                default -> null;
+            };
+        }
+
+        @Override
+        public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+            Fila f = filas.get(rowIndex);
+            if (columnIndex == 0 && aValue instanceof Insumo nuevo) {
+                for (int i = 0; i < filas.size(); i++) {
+                    if (i != rowIndex && filas.get(i).insumo != null
+                            && filas.get(i).insumo.getId().equals(nuevo.getId())) {
+                        Ui.warn(RegistrarTramiteDialog.this, "Ese insumo ya fue agregado.");
+                        return;
+                    }
+                }
+                f.insumo = nuevo;
+                int max = stockDisponible(nuevo);
+                if (f.cantidad > max) {
+                    f.cantidad = Math.max(1, max);
+                }
+            } else if (columnIndex == 2 && aValue instanceof Number n) {
+                f.cantidad = n.intValue();
+            }
+            fireTableRowsUpdated(rowIndex, rowIndex);
+        }
+    }
+
+    private static class Fila {
+        Insumo insumo;
+        int cantidad;
+
+        Fila(Insumo insumo, int cantidad) {
+            this.insumo = insumo;
+            this.cantidad = cantidad;
+        }
+    }
+
+    private class InsumoCellEditor extends AbstractCellEditor implements TableCellEditor {
+        private final JComboBox<Insumo> combo;
+
+        InsumoCellEditor() {
+            combo = new JComboBox<>(insumosDisponibles.toArray(new Insumo[0]));
+            combo.setRenderer(new DefaultListCellRenderer() {
+                @Override
+                public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                    Component c = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                    if (value instanceof Insumo ins) {
+                        String nombre = ins.getDescripcion() != null ? ins.getDescripcion() : ins.getCodigo();
+                        int stock = stockDisponible(ins);
+                        setText(String.format("%s (stock: %d)", nombre, stock));
+                    }
+                    return c;
+                }
+            });
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            return combo.getSelectedItem();
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+            combo.setSelectedItem(value);
+            return combo;
+        }
+    }
+
+    private class CantidadCellEditor extends AbstractCellEditor implements TableCellEditor {
+        private final JSpinner spinner = new JSpinner();
+
+        CantidadCellEditor() {
+            spinner.setModel(new SpinnerNumberModel(1, 1, Integer.MAX_VALUE, 1));
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            return spinner.getValue();
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+            Insumo ins = (Insumo) table.getValueAt(row, 0);
+            int max = Math.max(1, stockDisponible(ins));
+            SpinnerNumberModel model = (SpinnerNumberModel) spinner.getModel();
+            model.setMaximum(max);
+            model.setMinimum(1);
+            model.setValue(Math.min(value instanceof Number n ? n.intValue() : 1, max));
+            return spinner;
+        }
+    }
+}

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
@@ -33,6 +33,10 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
         this.service = service;
         table.setModel(model);
 
+        JButton btnRegistrarSalida = new JButton("Registrar retiro");
+        actionsPanel.add(btnRegistrarSalida, 0);
+        btnRegistrarSalida.addActionListener(e -> onRegistrarSalida());
+
         // ---- Ordenamiento y filtro
         sorter = new TableRowSorter<>(table.getModel());
         table.setRowSorter(sorter);
@@ -223,6 +227,16 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
             } catch (Exception e) {
                 Ui.error(this, e);
             }
+        }
+    }
+
+    private void onRegistrarSalida() {
+        Window owner = SwingUtilities.getWindowAncestor(this);
+        RegistrarTramiteDialog dlg = new RegistrarTramiteDialog(owner, service);
+        if (!dlg.isReady()) return;
+        dlg.setVisible(true);
+        if (dlg.isAccepted()) {
+            loadData();
         }
     }
 }

--- a/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
+++ b/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
@@ -1,0 +1,176 @@
+package ar.edu.unse.siga.service;
+
+import ar.edu.unse.siga.persistence.DataSourceFactory;
+import ar.edu.unse.siga.persistence.dao.InsumoDao;
+import ar.edu.unse.siga.persistence.dao.MovimientoDao;
+import ar.edu.unse.siga.persistence.dao.TramiteDao;
+import ar.edu.unse.siga.persistence.dao.TramiteDetalleDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcInsumoDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcMovimientoDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcTramiteDao;
+import ar.edu.unse.siga.persistence.jdbc.JdbcTramiteDetalleDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TramiteServiceTest {
+
+    private TramiteService service;
+
+    @BeforeEach
+    void setup() throws Exception {
+        try (Connection cn = DataSourceFactory.getConnection(); Statement st = cn.createStatement()) {
+            st.execute("DROP TABLE IF EXISTS tramite_detalle");
+            st.execute("DROP TABLE IF EXISTS movimiento");
+            st.execute("DROP TABLE IF EXISTS tramite");
+            st.execute("DROP TABLE IF EXISTS insumo");
+            st.execute("DROP TABLE IF EXISTS categoria");
+
+            st.execute("CREATE TABLE categoria (id INT AUTO_INCREMENT PRIMARY KEY, nombre VARCHAR(100), activo TINYINT)");
+            st.execute("CREATE TABLE insumo (" +
+                    "id INT AUTO_INCREMENT PRIMARY KEY, " +
+                    "codigo VARCHAR(64), " +
+                    "descripcion VARCHAR(255), " +
+                    "categoria_id INT, " +
+                    "stock_minimo INT, " +
+                    "ubicacion VARCHAR(100), " +
+                    "estado VARCHAR(20), " +
+                    "tipo VARCHAR(50), " +
+                    "stock DECIMAL(12,3) DEFAULT 0, " +
+                    "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, " +
+                    "fecha_alta DATE, " +
+                    "CONSTRAINT fk_cat FOREIGN KEY (categoria_id) REFERENCES categoria(id))");
+            st.execute("CREATE TABLE tramite (" +
+                    "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+                    "nro VARCHAR(30), " +
+                    "asunto VARCHAR(150), " +
+                    "estado VARCHAR(20), " +
+                    "fecha TIMESTAMP, " +
+                    "solicitante VARCHAR(100), " +
+                    "descripcion VARCHAR(255), " +
+                    "destino VARCHAR(150))");
+            st.execute("CREATE TABLE tramite_detalle (" +
+                    "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+                    "tramite_id BIGINT, " +
+                    "insumo_id INT, " +
+                    "cantidad DECIMAL(12,3), " +
+                    "CONSTRAINT fk_td_tram FOREIGN KEY (tramite_id) REFERENCES tramite(id), " +
+                    "CONSTRAINT fk_td_ins FOREIGN KEY (insumo_id) REFERENCES insumo(id))");
+            st.execute("CREATE TABLE movimiento (" +
+                    "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+                    "insumo_id INT, " +
+                    "tipo VARCHAR(20), " +
+                    "cantidad DECIMAL(12,3), " +
+                    "destino_fuente VARCHAR(150), " +
+                    "solicitante VARCHAR(100), " +
+                    "fecha TIMESTAMP, " +
+                    "usuario_id INT, " +
+                    "tramite_id BIGINT)");
+
+            st.execute("INSERT INTO categoria(id, nombre, activo) VALUES (1, 'General', 1)");
+            st.execute("INSERT INTO insumo(id, codigo, descripcion, categoria_id, stock_minimo, ubicacion, estado, tipo, stock) " +
+                    "VALUES (1, 'A', 'Insumo A', 1, 0, 'Depósito', 'ACTIVO', 'INSUMO', 10)");
+            st.execute("INSERT INTO insumo(id, codigo, descripcion, categoria_id, stock_minimo, ubicacion, estado, tipo, stock) " +
+                    "VALUES (2, 'B', 'Insumo B', 1, 0, 'Depósito', 'ACTIVO', 'INSUMO', 5)");
+            st.execute("INSERT INTO movimiento(insumo_id, tipo, cantidad, fecha) VALUES (1, 'ENTRADA', 10, CURRENT_TIMESTAMP())");
+            st.execute("INSERT INTO movimiento(insumo_id, tipo, cantidad, fecha) VALUES (2, 'ENTRADA', 5, CURRENT_TIMESTAMP())");
+        }
+
+        TramiteDao tramiteDao = new JdbcTramiteDao();
+        TramiteDetalleDao detalleDao = new JdbcTramiteDetalleDao();
+        MovimientoDao movimientoDao = new JdbcMovimientoDao();
+        InsumoDao insumoDao = new JdbcInsumoDao();
+        service = new TramiteService(tramiteDao, detalleDao, movimientoDao, insumoDao);
+    }
+
+    @Test
+    void registrarTramiteConMultiplesInsumos() throws Exception {
+        Long id = service.registrarNuevoTramite(List.of(
+                new TramiteService.LineaTramite(1, 3),
+                new TramiteService.LineaTramite(2, 2)
+        ));
+
+        assertNotNull(id);
+
+        try (Connection cn = DataSourceFactory.getConnection()) {
+            try (PreparedStatement ps = cn.prepareStatement("SELECT solicitante FROM tramite WHERE id=?")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals("Informes", rs.getString(1));
+                }
+            }
+
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(2, rs.getInt(1));
+                }
+            }
+
+            try (PreparedStatement ps = cn.prepareStatement("SELECT cantidad FROM movimiento WHERE tramite_id=? ORDER BY insumo_id")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(3, rs.getBigDecimal(1).intValue());
+                    assertTrue(rs.next());
+                    assertEquals(2, rs.getBigDecimal(1).intValue());
+                }
+            }
+
+            try (Statement st = cn.createStatement(); ResultSet rs = st.executeQuery("SELECT stock FROM insumo WHERE id = 1")) {
+                assertTrue(rs.next());
+                assertEquals(7, rs.getBigDecimal(1).intValue());
+            }
+        }
+    }
+
+    @Test
+    void rollbackPorStockInsuficiente() {
+        assertThrows(IllegalStateException.class, () ->
+                service.registrarNuevoTramite(List.of(new TramiteService.LineaTramite(2, 6))));
+
+        try (Connection cn = DataSourceFactory.getConnection(); Statement st = cn.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tramite")) {
+                assertTrue(rs.next());
+                assertEquals(0, rs.getInt(1));
+            }
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void unificaLineasDuplicadas() throws Exception {
+        Long id = service.registrarNuevoTramite(List.of(
+                new TramiteService.LineaTramite(1, 2),
+                new TramiteService.LineaTramite(1, 3)
+        ));
+
+        try (Connection cn = DataSourceFactory.getConnection()) {
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(1, rs.getInt(1));
+                }
+            }
+
+            try (PreparedStatement ps = cn.prepareStatement("SELECT cantidad FROM movimiento WHERE tramite_id=?")) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(5, rs.getBigDecimal(1).intValue());
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+db.url=jdbc:h2:mem:siga;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+db.user=sa
+db.password=


### PR DESCRIPTION
## Summary
- implement TramiteService workflow to registrar trámites con múltiples insumos en una única transacción y asociar movimientos de salida
- agregar RegistrarTramiteDialog y actualizar TramiteFrame para capturar salidas multi-ítem con validaciones de stock
- extender DAOs/JDBC con TramiteDetalle, salidas transaccionales y pruebas sobre H2 para éxito, rollback y duplicados

## Testing
- mvn test *(falla: no se pudo descargar junit-bom desde Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa9edd30c8321b373ba398e2e30f4