### PR TITLE
feat: rename trámites UI to solicitudes with multi-insumo registration

### DIFF
--- a/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDao.java
+++ b/src/main/java/ar/edu/unse/siga/persistence/jdbc/JdbcTramiteDao.java
@@ -158,7 +158,7 @@ public class JdbcTramiteDao implements TramiteDao {
         }
     }
 
-    /** NUEVO: últimos N trámites por fecha desc (para “Trámites recientes”). */
+    /** NUEVO: últimas N solicitudes por fecha desc (para “Solicitudes recientes”). */
     @Override
     public List<Tramite> listRecientes(int limit) {
         final String sql = """

--- a/src/main/java/ar/edu/unse/siga/service/InventarioService.java
+++ b/src/main/java/ar/edu/unse/siga/service/InventarioService.java
@@ -158,6 +158,10 @@ public class InventarioService {
 
     public List<Insumo> listarTodos() { return insumoDao.listAll(); }
 
+    public List<Insumo> insumosConStockDisponible() {
+        return insumoDao.listActivosConStock();
+    }
+
     // === Movimientos ===
     public Long registrarMovimiento(Long insumoId,
                                     String tipo,

--- a/src/main/java/ar/edu/unse/siga/service/TramiteService.java
+++ b/src/main/java/ar/edu/unse/siga/service/TramiteService.java
@@ -24,7 +24,6 @@ public class TramiteService {
     private final TramiteDetalleDao tramiteDetalleDao;
     private final MovimientoDao movimientoDao;
     private final InsumoDao insumoDao;
-    private static final String SOLICITANTE_INFORMES = "Informes";
 
     public TramiteService(TramiteDao tramiteDao) {
         this(tramiteDao, null, null, null);
@@ -116,9 +115,16 @@ public java.util.List<Tramite> tramitesRecientes(int limit) {
         return insumoDao.listActivosConStock();
     }
 
-    public Long registrarNuevoTramite(List<LineaTramite> lineas) {
+    public Long registrarNuevoTramite(String solicitud,
+                                      String solicitante,
+                                      String descripcion,
+                                      String destino,
+                                      List<LineaTramite> lineas) {
         if (movimientoDao == null || insumoDao == null || tramiteDetalleDao == null) {
             throw new IllegalStateException("Dependencias no configuradas para registrar trámite con insumos");
+        }
+        if (solicitud == null || solicitud.isBlank()) {
+            throw new IllegalArgumentException("La solicitud es obligatoria");
         }
         if (lineas == null || lineas.isEmpty()) {
             throw new IllegalArgumentException("Debe indicar al menos un insumo");
@@ -135,17 +141,26 @@ public java.util.List<Tramite> tramitesRecientes(int limit) {
             porInsumo.merge(l.insumoId, BigDecimal.valueOf(l.cantidad), BigDecimal::add);
         });
 
+        String solicitudTrim = solicitud.trim();
+        String solicitanteTrim = solicitante != null ? solicitante.trim() : "";
+        String destinoTrim = destino != null ? destino.trim() : "";
+        String descripcionTrim = descripcion != null ? descripcion.trim() : "";
+
+        String solicitanteFinal = solicitanteTrim.isEmpty() ? "Sin solicitante" : solicitanteTrim;
+        String destinoFinal = destinoTrim.isEmpty() ? "Secretaría FCEyT" : destinoTrim;
+        String descripcionFinal = descripcionTrim.isEmpty() ? null : descripcionTrim;
+
         try (Connection cn = DataSourceFactory.getConnection()) {
             boolean originalAuto = cn.getAutoCommit();
             try {
                 cn.setAutoCommit(false);
 
                 Tramite tramite = new Tramite();
-                tramite.setNro("");
-                tramite.setAsunto("Salida de insumos");
-                tramite.setSolicitante(SOLICITANTE_INFORMES);
-                tramite.setDescripcion("Trámite generado automáticamente para entrega de insumos.");
-                tramite.setDestino("Informes");
+                tramite.setNro(generarNumeroTramite());
+                tramite.setAsunto(solicitudTrim);
+                tramite.setSolicitante(solicitanteFinal);
+                tramite.setDescripcion(descripcionFinal);
+                tramite.setDestino(destinoFinal);
                 tramite.setEstado("NUEVO");
                 tramite.setFecha(LocalDateTime.now());
                 Long tramiteId = tramiteDao.create(tramite, cn);
@@ -168,7 +183,7 @@ public java.util.List<Tramite> tramitesRecientes(int limit) {
                     tramiteDetalleDao.create(detalle, cn);
 
                     try {
-                        movimientoDao.registrarSalida(cn, insumoId, cantidad, SOLICITANTE_INFORMES, tramiteId);
+                        movimientoDao.registrarSalida(cn, insumoId, cantidad, solicitanteFinal, tramiteId);
                     } catch (IllegalStateException ex) {
                         throw new IllegalStateException("El stock cambió. Revisá cantidades e intentá nuevamente.", ex);
                     }
@@ -181,13 +196,19 @@ public java.util.List<Tramite> tramitesRecientes(int limit) {
                 if (e instanceof IllegalStateException) {
                     throw e;
                 }
-                throw new RuntimeException("No se pudo registrar el trámite", e);
+                throw new RuntimeException("No se pudo registrar la solicitud", e);
             } finally {
                 try { cn.setAutoCommit(originalAuto); } catch (SQLException ignored) {}
             }
         } catch (SQLException e) {
-            throw new RuntimeException("Error registrando trámite", e);
+            throw new RuntimeException("Error registrando la solicitud", e);
         }
+    }
+
+    private String generarNumeroTramite() {
+        String fecha = java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+        int random = (int) (Math.random() * 90000) + 10000;
+        return fecha + "-" + random;
     }
 
     public static class LineaTramite {

--- a/src/main/java/ar/edu/unse/siga/ui/App.java
+++ b/src/main/java/ar/edu/unse/siga/ui/App.java
@@ -1,8 +1,6 @@
 package ar.edu.unse.siga.ui;
 
-
 import ar.edu.unse.siga.config.AppServices;
-import ar.edu.unse.siga.ui.shell.MainShellFrame;
 
 public class App {
     public static void main(String[] args) {
@@ -10,7 +8,7 @@ public class App {
         javax.swing.SwingUtilities.invokeLater(() -> {
             // inicializamos una vez los servicios
             AppServices.init();
-            new MainShellFrame().setVisible(true);
+            AppLauncher.launch();
         });
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/AppLauncher.java
+++ b/src/main/java/ar/edu/unse/siga/ui/AppLauncher.java
@@ -21,13 +21,14 @@ public class AppLauncher {
         MovimientoDao movDao = new JdbcMovimientoDao();
         UsuarioDao usuarioDao = new JdbcUsuarioDao();
         TramiteDao tramiteDao = new JdbcTramiteDao();
+        TramiteDetalleDao tramiteDetalleDao = new JdbcTramiteDetalleDao();
         CategoriaDao categoriaDao = new JdbcCategoriaDao();
         UbicacionDao ubicacionDao = new JdbcUbicacionDao();
 
         // Services
         AuthService auth = new AuthService(usuarioDao);
         InventarioService inv = new InventarioService(insumoDao, movDao, categoriaDao, ubicacionDao);
-        TramiteService tra = new TramiteService(tramiteDao);
+        TramiteService tra = new TramiteService(tramiteDao, tramiteDetalleDao, movDao, insumoDao);
         
         
 

--- a/src/main/java/ar/edu/unse/siga/ui/MainFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/MainFrame.java
@@ -62,7 +62,7 @@ public class MainFrame extends JFrame {
         var btnIns = new JButton("Insumos", ThemeManager.svg("icons/add.svg", 16));
         btnIns.addActionListener(e -> openInDesktop(new ar.edu.unse.siga.ui.inventario.InsumoFrame(inventarioService)));
 
-        var btnTra = new JButton("Trámites", ThemeManager.svg("icons/search.svg", 16));
+        var btnTra = new JButton("Solicitudes", ThemeManager.svg("icons/search.svg", 16));
         btnTra.addActionListener(e -> openInDesktop(new TramiteFrame(tramiteService, inventarioService)));
 
         var btnCsv = new JButton("Movimientos CSV", ThemeManager.svg("icons/csv.svg", 16));
@@ -97,8 +97,8 @@ public class MainFrame extends JFrame {
         mInventario.addSeparator();
         mInventario.add(miReporte);
 
-        var mTramites = new JMenu("Trámites");
-        var miTramites = new JMenuItem("ABM Trámites");
+        var mTramites = new JMenu("Solicitudes");
+        var miTramites = new JMenuItem("ABM Solicitudes");
         miTramites.addActionListener(e -> openInDesktop(new TramiteFrame(tramiteService, inventarioService)));
         mTramites.add(miTramites);
 
@@ -185,7 +185,7 @@ public static MainFrame defaultWired() {
     // Services
     AuthService auth = new AuthService(usuarioDao);
 
-    // Inventario y Trámite salen de AppServices
+    // Inventario y Solicitudes salen de AppServices
     var inv = AppServices.inventario();
     var tra = AppServices.tramite();
 

--- a/src/main/java/ar/edu/unse/siga/ui/TramiteTableModel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/TramiteTableModel.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TramiteTableModel extends AbstractTableModel {
-    private final String[] cols = {"ID","Nro","Asunto","Estado","Fecha","Solicitante"};
+    private final String[] cols = {"ID","Nro","Solicitud","Estado","Fecha","Solicitante"};
     private final List<Tramite> data = new ArrayList<>();
 
     public void setData(List<Tramite> list) {

--- a/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
@@ -20,9 +20,9 @@ import java.math.BigDecimal;
 /**
  * Dashboard de Inicio con métricas y actividad reciente dinámica.
  * - Usa InventarioService para métricas en tiempo real.
- * - Usa TramiteService para cargar los últimos movimientos de trámites.
+ * - Usa TramiteService para cargar las últimas solicitudes registradas.
  * - Expone recargarTramitesRecientes() para que TramiteEntradaPage actualice la actividad
- *   inmediatamente después de registrar un nuevo trámite.
+ *   inmediatamente después de registrar una nueva solicitud.
  */
 public class HomePage extends JPanel {
 
@@ -32,7 +32,7 @@ public class HomePage extends JPanel {
     public interface HomeNavigation {
         void navigateTo(String key);
         void openInventarioBajoMinimo();
-        void openTramitesNuevos();
+        void openSolicitudesNuevas();
         void openMovimientosHoy();
     }
 
@@ -40,7 +40,7 @@ public class HomePage extends JPanel {
 
     // Labels de métricas (para refrescar)
     private JLabel lblInsumosCriticos;
-    private JLabel lblTramitesNuevos;
+    private JLabel lblSolicitudesNuevas;
     private JLabel lblSalidasHoy;
     private JLabel lblAlertStock;
 
@@ -193,8 +193,8 @@ public class HomePage extends JPanel {
 
         row.add(metricCard("Insumos bajo mínimo", lblInsumosCriticos = new JLabel("0"),
                 "Stock por reponer", new Color(255, 99, 99), this::openInventarioBajoMinimo));
-        row.add(metricCard("Trámites nuevos", lblTramitesNuevos = new JLabel("0"),
-                "Ingresados recientemente", new Color(86, 127, 255), this::openTramitesNuevos));
+        row.add(metricCard("Solicitudes nuevas", lblSolicitudesNuevas = new JLabel("0"),
+                "Ingresadas recientemente", new Color(86, 127, 255), this::openSolicitudesNuevas));
         row.add(metricCard("Últimas salidas (hoy)", lblSalidasHoy = new JLabel("0"),
                 "Movimientos registrados hoy", new Color(58, 182, 186), this::openMovimientosHoy));
         return row;
@@ -354,7 +354,7 @@ public class HomePage extends JPanel {
         }
 
         lblInsumosCriticos.setText(String.valueOf(criticos));
-        lblTramitesNuevos.setText(String.valueOf(tramitesNuevos));
+        lblSolicitudesNuevas.setText(String.valueOf(tramitesNuevos));
         lblSalidasHoy.setText(String.valueOf(salidasHoy));
         updateAlertStock(criticos);
     }
@@ -415,8 +415,8 @@ public class HomePage extends JPanel {
         else navigateOrInfo("inventario");
     }
 
-    private void openTramitesNuevos() {
-        if (navigation != null) navigation.openTramitesNuevos();
+    private void openSolicitudesNuevas() {
+        if (navigation != null) navigation.openSolicitudesNuevas();
         else navigateOrInfo("tramites");
     }
 
@@ -478,7 +478,7 @@ public class HomePage extends JPanel {
 
     private String descripcionActividad(Tramite t) {
         String nro = (t.getNro() == null || t.getNro().isBlank()) ? "-" : t.getNro();
-        String asunto = (t.getAsunto() == null || t.getAsunto().isBlank()) ? "Trámite sin asunto" : t.getAsunto();
+        String asunto = (t.getAsunto() == null || t.getAsunto().isBlank()) ? "Solicitud sin asunto" : t.getAsunto();
         String estado = estadoFriendly(t.getEstado());
         String solicitante = (t.getSolicitante() == null || t.getSolicitante().isBlank())
                 ? ""

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -22,8 +22,8 @@ import static javax.swing.SwingConstants.CENTER;
 import static javax.swing.SwingConstants.LEFT;
 
 /**
- * Pantalla de Trámites: registro + listados.
- * - Sidebar: "Trámites recientes" dinámico.
+ * Pantalla de Solicitudes: registro + listados.
+ * - Sidebar: "Solicitudes recientes" dinámico.
  * - Tabla de activos con edición inline del estado.
  * - Callback onTramiteCreado para notificar a HomePage.
  */
@@ -59,7 +59,7 @@ public class TramiteEntradaPage extends JPanel {
     // Tabla (solo columna Estado editable)
     private final JTable table = new JTable(new DefaultTableModel(
             new Object[][]{},
-            new String[]{"ID Trámite", "Asunto", "Fecha creación", "Última actualización", "Descripcion", "Estado"}
+            new String[]{"ID Solicitud", "Solicitud", "Fecha creación", "Última actualización", "Descripcion", "Estado"}
     )) {
         @Override
         public boolean isCellEditable(int row, int column) {
@@ -67,7 +67,7 @@ public class TramiteEntradaPage extends JPanel {
         }
     };
 
-    // Panel dinámico del sidebar "Trámites recientes"
+    // Panel dinámico del sidebar "Solicitudes recientes"
     private JPanel recientesSidebar;
 
     /* ========================  Constructores  ========================= */
@@ -135,7 +135,7 @@ public class TramiteEntradaPage extends JPanel {
                     String friendly = estadoFriendly(canon);
                     updatingEstado = true;
                     table.setValueAt(friendly, row, 5);
-                    recargarTramitesRecientesSidebar(); // 🔄 refresca el panel de trámites recientes
+                    recargarTramitesRecientesSidebar(); // 🔄 refresca el panel de solicitudes recientes
 
                 } catch (Exception ex) {
                     Ui.error(this, ex);
@@ -152,14 +152,14 @@ public class TramiteEntradaPage extends JPanel {
         JPanel header = new JPanel(new BorderLayout());
         header.setOpaque(false);
 
-        JLabel title = new JLabel("Trámites");
+        JLabel title = new JLabel("Solicitudes");
         title.setFont(new Font("Segoe UI", Font.BOLD, 32));
         title.setForeground(new Color(35, 55, 120));
         header.add(title, BorderLayout.WEST);
 
         ButtonGroup tabs = new ButtonGroup();
-        tabRegistrar = tabButton("Registrar nuevo trámite");
-        tabActivos   = tabButton("Trámites activos");
+        tabRegistrar = tabButton("Registrar nueva solicitud");
+        tabActivos   = tabButton("Estados de solicitudes");
         tabs.add(tabRegistrar);
         tabs.add(tabActivos);
         tabRegistrar.setSelected(true);
@@ -211,7 +211,7 @@ public class TramiteEntradaPage extends JPanel {
         CardPanel card = new CardPanel();
         card.setLayout(new BorderLayout(18, 18));
 
-        JLabel title = new JLabel("Detalle del trámite");
+        JLabel title = new JLabel("Detalle de la solicitud");
         title.setFont(new Font("Segoe UI", Font.BOLD, 16));
         title.setForeground(new Color(54, 92, 190));
         card.add(title, BorderLayout.NORTH);
@@ -222,7 +222,7 @@ public class TramiteEntradaPage extends JPanel {
 
         form.add(infoLabel("Número generado", lblNumero));
         form.add(Box.createVerticalStrut(16));
-        form.add(field("Asunto", txtAsunto));
+        form.add(field("Solicitud", txtAsunto));
         form.add(Box.createVerticalStrut(14));
         form.add(field("Solicitante", txtSolicitante));
         form.add(Box.createVerticalStrut(14));
@@ -254,7 +254,7 @@ public class TramiteEntradaPage extends JPanel {
 
 
 private JComponent buildSidebarPanel() {
-    // Solo el panel de trámites recientes, sin los antiguos
+    // Solo el panel de solicitudes recientes, sin los antiguos
     CardPanel soloRecientes = recentTramitesCard();
     return soloRecientes;
 }
@@ -263,7 +263,7 @@ private JComponent buildSidebarPanel() {
 private CardPanel recentTramitesCard() {
     CardPanel card = new CardPanel();
     card.setLayout(new BorderLayout(0, 12));
-    card.add(sideTitle("Trámites recientes"), BorderLayout.NORTH);
+        card.add(sideTitle("Solicitudes recientes"), BorderLayout.NORTH);
 
     recientesSidebar = new JPanel();
     recientesSidebar.setBorder(new javax.swing.border.EmptyBorder(8, 12, 12, 16)); // top,left,bottom,right
@@ -295,7 +295,7 @@ private CardPanel recentTramitesCard() {
 
 
 
-    /** Reconstruye la lista de “Trámites recientes” en el sidebar. */
+    /** Reconstruye la lista de “Solicitudes recientes” en el sidebar. */
   private void recargarTramitesRecientesSidebar() {
     if (recientesSidebar == null) return;
 
@@ -304,7 +304,7 @@ private CardPanel recentTramitesCard() {
     try {
         java.util.List<Tramite> ult = service.tramitesRecientes(20);
         for (Tramite t : ult) {
-            String asunto = "Asunto: " + (t.getAsunto() == null ? "-" : t.getAsunto());
+            String solicitudTxt = "Solicitud: " + (t.getAsunto() == null ? "-" : t.getAsunto());
             String estado = "Estado: " + (t.getEstado() == null ? "-" : t.getEstado());
 
             String badgeTxt = estadoFriendly(t.getEstado());
@@ -315,7 +315,7 @@ private CardPanel recentTramitesCard() {
                         default -> new Color(255, 170, 70); // pendiente
                     };
 
-            Component item = recentItem(asunto, estado, badgeTxt, badgeColor);
+            Component item = recentItem(solicitudTxt, estado, badgeTxt, badgeColor);
             // opcional: asegurar ancho completo
             if (item instanceof JComponent jc) jc.setMaximumSize(new Dimension(Integer.MAX_VALUE, jc.getPreferredSize().height));
 
@@ -413,7 +413,7 @@ private CardPanel recentTramitesCard() {
             service.registrarTramite(nro, asunto, solicitante,
                     (descripcion != null && !descripcion.isBlank()) ? descripcion : null, destino);
 
-            Ui.info(this, "Trámite registrado correctamente.");
+            Ui.info(this, "Solicitud registrada correctamente.");
 
             // Reset de campos
             lblNumero.setText(generateNumero(LocalDate.now()));

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -47,7 +47,7 @@ import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
 
 /**
- * Panel de Informes con tres secciones: INVENTARIO, TRÁMITES y MOVIMIENTOS.
+ * Panel de Informes con tres secciones: INVENTARIO, SOLICITUDES y MOVIMIENTOS.
  * Incluye exportación a PDF/CSV y encabezado de PDF con logo, fecha, generado
  * por y filtros.
  */
@@ -81,12 +81,12 @@ public class InformesPanel extends JPanel {
         }
     };
 
-    // --- TRÁMITES (filtros) ---
+    // --- SOLICITUDES (filtros) ---
     private final JTextField filterSearch = new JTextField(18);
     private final JComboBox<String> filterEstado
             = new JComboBox<>(new String[]{"Todos", "Completado", "En proceso", "Pendiente"});
     private final DefaultTableModel modelTra = new DefaultTableModel(
-            new Object[]{"ID Trámite", "Asunto", "Fecha creación", "Última actualización", "Descripción", "Solicitante", "Estado"}, 0
+            new Object[]{"ID Solicitud", "Solicitud", "Fecha creación", "Última actualización", "Descripción", "Solicitante", "Estado"}, 0
     ) {
         @Override
         public boolean isCellEditable(int r, int c) {
@@ -94,7 +94,7 @@ public class InformesPanel extends JPanel {
         }
     };
 
-    // --- MOVIMIENTOS (similar a Trámites de UI) ---
+    // --- MOVIMIENTOS (similar a Solicitudes de UI) ---
     private final JTextField filterSearchMov = new JTextField(18);
     private final DefaultTableModel modelMov = new DefaultTableModel(
             new Object[]{"Fecha", "Tipo", "Cantidad", "Código", "Descripción", "Ubicación", "Destino", "Solicitante"}, 0
@@ -114,7 +114,7 @@ public class InformesPanel extends JPanel {
 
     private final javax.swing.table.DefaultTableModel retirosModel
             = new javax.swing.table.DefaultTableModel(
-                    new Object[]{"# Trámite", "Fecha", "Insumo", "Cantidad"}, 0) {
+                    new Object[]{"# Solicitud", "Fecha", "Insumo", "Cantidad"}, 0) {
         @Override
         public boolean isCellEditable(int r, int c) {
             return false;
@@ -233,7 +233,7 @@ public class InformesPanel extends JPanel {
                 String cantidad = (m.getCantidad() == null) ? "0"
                         : m.getCantidad().stripTrailingZeros().toPlainString();
 
-                // #Trámite: si tu Movimiento expone el id/nro del trámite, usalo;
+                // #Solicitud: si tu Movimiento expone el id/nro de la solicitud, usalo;
                 // si no, mostramos "-" hasta que lo agreguemos al modelo:
                 String nroTramite = "-";
                 try {
@@ -358,7 +358,7 @@ public class InformesPanel extends JPanel {
         // Tabs tipo "pill"
         ButtonGroup tabs = new ButtonGroup();
         btnInventario = pill("INVENTARIO");
-        btnTramites = pill("TRÁMITES");
+        btnTramites = pill("SOLICITUDES");
         btnMovimientos = pill("MOVIMIENTOS");
         btnInventario.setSelected(true);
         tabs.add(btnInventario);
@@ -380,14 +380,14 @@ public class InformesPanel extends JPanel {
         invPanel.add(buildMetrics(), BorderLayout.NORTH);
         invPanel.add(buildInventarioSplit(), BorderLayout.CENTER);
 
-        // TRÁMITES
+        // SOLICITUDES
         JPanel traPanel = new JPanel(new BorderLayout(12, 12));
         traPanel.setOpaque(true);
         traPanel.setBackground(Color.WHITE);
         traPanel.add(buildTramitesFilters(), BorderLayout.NORTH);
         traPanel.add(buildTramitesTableScroll(), BorderLayout.CENTER);
 
-        // MOVIMIENTOS (misma estética que TRÁMITES)
+        // MOVIMIENTOS (misma estética que SOLICITUDES)
         JPanel movPanel = new JPanel(new BorderLayout(12, 12));
         movPanel.setOpaque(true);
         movPanel.setBackground(Color.WHITE);
@@ -640,7 +640,7 @@ public class InformesPanel extends JPanel {
 
         CardPanel c1 = metricCardGradient("TOTAL INSUMOS", lblTotalInsumos,
                 new Color(70, 120, 255), new Color(110, 150, 255));
-        CardPanel c2 = metricCardGradient("TRÁMITES", lblTotalTramites,
+        CardPanel c2 = metricCardGradient("SOLICITUDES", lblTotalTramites,
                 new Color(70, 120, 255), new Color(140, 170, 255));
 
         c1.setPreferredSize(new Dimension(420, 110));
@@ -783,7 +783,7 @@ public class InformesPanel extends JPanel {
         }).collect(Collectors.toList());
     }
 
-    // ====== TRÁMITES ======
+    // ====== SOLICITUDES ======
     private Component buildTramitesFilters() {
         JPanel panel = new JPanel(new BorderLayout(18, 0));
         panel.setOpaque(false);
@@ -1372,8 +1372,8 @@ public class InformesPanel extends JPanel {
         }
         // Ajuste de headers para que coincida con modelTra (7 columnas, incluida "Solicitante")
         exportModelToPdf(
-                "INFORME DE TRÁMITES",
-                new String[]{"ID Trámite", "Asunto", "Fecha creación", "Última actualización", "Descripción", "Solicitante", "Estado"},
+                "INFORME DE SOLICITUDES",
+                new String[]{"ID Solicitud", "Solicitud", "Fecha creación", "Última actualización", "Descripción", "Solicitante", "Estado"},
                 modelTra,
                 estadoFiltro,
                 null,
@@ -1482,7 +1482,7 @@ public class InformesPanel extends JPanel {
             StringBuilder filtros = new StringBuilder();
             if (categoriaFiltro != null && !categoriaFiltro.isBlank()) {
                 String etiqueta;
-                if ("INFORME DE TRÁMITES".equalsIgnoreCase(titulo)) {
+                if ("INFORME DE SOLICITUDES".equalsIgnoreCase(titulo)) {
                     etiqueta = "Estado";
                 } else if ("INFORME DE MOVIMIENTOS".equalsIgnoreCase(titulo)) {
                     etiqueta = "Movimiento";
@@ -1964,7 +1964,7 @@ public class InformesPanel extends JPanel {
     }
 
     /**
-     * Útil si sólo querés refrescar la grilla de Trámites.
+     * Útil si sólo querés refrescar la grilla de Solicitudes.
      */
     public void reloadTramitesUI() {
         SwingUtilities.invokeLater(this::loadTableDataTramites);

--- a/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
@@ -76,7 +76,7 @@ public class ShellFrame extends JFrame {
                 case "inventario" -> "Inventario";
                 case "movimientos" -> "Movimientos";
                 case "reportes" -> "Informes";
-                case "tramites" -> "Trámites";
+                case "tramites" -> "Solicitudes";
                 case "finanzas" -> "Finanzas";
                 default -> key;
             };
@@ -102,7 +102,7 @@ public class ShellFrame extends JFrame {
             }
 
             @Override
-            public void openTramitesNuevos() {
+            public void openSolicitudesNuevas() {
                 nav.accept("tramites");
                 if (tramitesHolder[0] != null) {
                     tramitesHolder[0].mostrarTramitesEstado("NUEVO");
@@ -183,7 +183,7 @@ public class ShellFrame extends JFrame {
         NavButton bInv = nav("Inventario", "ui/icons/inventory.svg", "inventario");
         NavButton bMov = nav("Movimientos", "ui/icons/movements.svg", "movimientos", 1);
         NavButton bInf = nav("Informes", "ui/icons/reports.svg", "reportes");
-        NavButton bTra = nav("Trámites", "ui/icons/tramites.svg", "tramites");
+        NavButton bTra = nav("Solicitudes", "ui/icons/tramites.svg", "tramites");
         // NavButton bFin  = nav("Finanzas",     "ui/icons/finanzas.svg",   "finanzas");
 
         navGroup.add(bHome);

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
@@ -23,7 +23,7 @@ public class RegistrarTramiteDialog extends JDialog {
     private final InventarioService inventarioService;
     private final JTable table = new JTable();
     private final LineaTableModel model = new LineaTableModel();
-    private final JButton btnGuardar = new JButton("Guardar");
+    private final JButton btnGuardar = new JButton("Registrar");
     private final JLabel lblTotales = new JLabel("0 ítems · 0 unidades");
     private boolean accepted = false;
     private final JTextField txtSolicitud = new JTextField(30);
@@ -51,7 +51,7 @@ public class RegistrarTramiteDialog extends JDialog {
         setLayout(new BorderLayout(10, 10));
         txtDescripcion.setLineWrap(true);
         txtDescripcion.setWrapStyleWord(true);
-        lblNumero.setText("Se generará al guardar");
+        lblNumero.setText("Se generará al registrar");
         lblNumero.setFont(lblNumero.getFont().deriveFont(Font.BOLD));
 
         add(buildFormPanel(), BorderLayout.NORTH);

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
@@ -1,10 +1,12 @@
 package ar.edu.unse.siga.ui.tramites;
 
 import ar.edu.unse.siga.domain.Insumo;
+import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.ui.base.Ui;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
@@ -18,18 +20,25 @@ import java.util.List;
 public class RegistrarTramiteDialog extends JDialog {
 
     private final TramiteService tramiteService;
+    private final InventarioService inventarioService;
     private final JTable table = new JTable();
     private final LineaTableModel model = new LineaTableModel();
     private final JButton btnGuardar = new JButton("Guardar");
     private final JLabel lblTotales = new JLabel("0 ítems · 0 unidades");
     private boolean accepted = false;
+    private final JTextField txtSolicitud = new JTextField(30);
+    private final JTextField txtSolicitante = new JTextField(25);
+    private final JTextArea txtDescripcion = new JTextArea(4, 25);
+    private final JTextField txtDestino = new JTextField(25);
+    private final JLabel lblNumero = new JLabel();
     private final List<Insumo> insumosDisponibles;
     private final boolean ready;
 
-    public RegistrarTramiteDialog(Window owner, TramiteService tramiteService) {
-        super(owner, "Registrar trámite de salida", ModalityType.APPLICATION_MODAL);
+    public RegistrarTramiteDialog(Window owner, TramiteService tramiteService, InventarioService inventarioService) {
+        super(owner, "Registrar solicitud", ModalityType.APPLICATION_MODAL);
         this.tramiteService = tramiteService;
-        this.insumosDisponibles = new ArrayList<>(tramiteService.insumosConStockDisponible());
+        this.inventarioService = inventarioService;
+        this.insumosDisponibles = new ArrayList<>(inventarioService.insumosConStockDisponible());
         this.ready = !insumosDisponibles.isEmpty();
 
         if (!ready) {
@@ -40,6 +49,13 @@ public class RegistrarTramiteDialog extends JDialog {
         }
 
         setLayout(new BorderLayout(10, 10));
+        txtDescripcion.setLineWrap(true);
+        txtDescripcion.setWrapStyleWord(true);
+        lblNumero.setText("Se generará al guardar");
+        lblNumero.setFont(lblNumero.getFont().deriveFont(Font.BOLD));
+
+        add(buildFormPanel(), BorderLayout.NORTH);
+
         table.setModel(model);
         table.setRowHeight(26);
         table.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
@@ -74,6 +90,17 @@ public class RegistrarTramiteDialog extends JDialog {
             }
         });
 
+        txtSolicitud.getDocument().addDocumentListener(new javax.swing.event.DocumentListener() {
+            @Override
+            public void insertUpdate(javax.swing.event.DocumentEvent e) { updateState(); }
+
+            @Override
+            public void removeUpdate(javax.swing.event.DocumentEvent e) { updateState(); }
+
+            @Override
+            public void changedUpdate(javax.swing.event.DocumentEvent e) { updateState(); }
+        });
+
         model.addEmptyRow();
         updateState();
 
@@ -82,20 +109,100 @@ public class RegistrarTramiteDialog extends JDialog {
         setLocationRelativeTo(owner);
     }
 
+    private JPanel buildFormPanel() {
+        JPanel form = new JPanel(new GridBagLayout());
+        form.setBorder(new EmptyBorder(8, 8, 8, 8));
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4, 4, 4, 4);
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        form.add(new JLabel("N° automático:"), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        form.add(lblNumero, gbc);
+
+        gbc.gridy++;
+        gbc.gridx = 0;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        form.add(new JLabel("Solicitud:"), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        form.add(txtSolicitud, gbc);
+
+        gbc.gridy++;
+        gbc.gridx = 0;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        form.add(new JLabel("Solicitante:"), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        form.add(txtSolicitante, gbc);
+
+        gbc.gridy++;
+        gbc.gridx = 0;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        form.add(new JLabel("Descripción:"), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.BOTH;
+        JScrollPane descripcionScroll = new JScrollPane(txtDescripcion);
+        descripcionScroll.setPreferredSize(new Dimension(0, 90));
+        form.add(descripcionScroll, gbc);
+
+        gbc.gridy++;
+        gbc.gridx = 0;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        form.add(new JLabel("Destino:"), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        form.add(txtDestino, gbc);
+
+        return form;
+    }
+
     private void updateState() {
         lblTotales.setText(model.totales());
-        btnGuardar.setEnabled(model.isValidRows());
+        boolean hasSolicitud = txtSolicitud.getText() != null && !txtSolicitud.getText().trim().isEmpty();
+        btnGuardar.setEnabled(hasSolicitud && model.isValidRows());
     }
 
     private void onGuardar() {
+        String solicitud = txtSolicitud.getText() != null ? txtSolicitud.getText().trim() : "";
+        if (solicitud.isEmpty()) {
+            Ui.warn(this, "La solicitud es obligatoria.");
+            return;
+        }
         if (!model.isValidRows()) {
             Ui.warn(this, "Completá correctamente todas las filas.");
             return;
         }
         List<TramiteService.LineaTramite> lineas = model.toLineas();
+        if (lineas.isEmpty()) {
+            Ui.warn(this, "Agregá al menos un insumo.");
+            return;
+        }
+        String solicitante = txtSolicitante.getText() != null ? txtSolicitante.getText().trim() : "";
+        String descripcion = txtDescripcion.getText() != null ? txtDescripcion.getText().trim() : "";
+        String destino = txtDestino.getText() != null ? txtDestino.getText().trim() : "";
         try {
-            Long id = tramiteService.registrarNuevoTramite(lineas);
-            Ui.info(this, "Trámite registrado. ID: " + id);
+            Long id = tramiteService.registrarNuevoTramite(
+                    solicitud,
+                    solicitante.isEmpty() ? null : solicitante,
+                    descripcion.isEmpty() ? null : descripcion,
+                    destino.isEmpty() ? null : destino,
+                    lineas
+            );
+            Ui.info(this, "Solicitud registrada. ID: " + id);
             accepted = true;
             dispose();
         } catch (IllegalStateException ex) {

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFormDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFormDialog.java
@@ -19,7 +19,7 @@ public class TramiteFormDialog extends JDialog {
 
     /** Nuevo constructor con callback (recomendado) */
     public TramiteFormDialog(Window owner, Runnable onSaved) {
-        super(owner, "Nuevo Trámite", ModalityType.APPLICATION_MODAL);
+        super(owner, "Nueva Solicitud", ModalityType.APPLICATION_MODAL);
         this.onSaved = onSaved;
         buildUI(owner);
     }
@@ -35,7 +35,7 @@ public class TramiteFormDialog extends JDialog {
         form.add(new JLabel("Número:"));
         form.add(txtNro);
 
-        form.add(new JLabel("Asunto:"));
+        form.add(new JLabel("Solicitud:"));
         form.add(txtAsunto);
 
         form.add(new JLabel("Solicitante:"));
@@ -58,7 +58,7 @@ public class TramiteFormDialog extends JDialog {
                 return;
             }
             // Aquí deberías invocar tu Service para:
-            // - crear Tramite + Detalles
+            // - crear Solicitud + Detalles
             // - crear Movimientos SALIDA por los insumos seleccionados
             // - descontar stock
             // (todo en una transacción). Este diálogo sólo valida y notifica.

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
@@ -10,6 +10,7 @@ import ar.edu.unse.siga.ui.base.UiBus;
 import ar.edu.unse.siga.ui.reportes.InformesPanel;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -27,19 +28,17 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
 
     private final JTextField txtSearch = new JTextField(20);
     private final JComboBox<String> cbCampo
-            = new JComboBox<>(new String[]{"ID", "Nro", "Asunto", "Estado", "Fecha", "Solicitante"});
+            = new JComboBox<>(new String[]{"ID", "Nro", "Solicitud", "Estado", "Fecha", "Solicitante"});
 
     private TableRowSorter<TableModel> sorter;
 
     public TramiteFrame(TramiteService service, InventarioService invService) {
-        super("ABM Trámites");
+        super("Solicitudes");
         this.service = service;
         this.invService = invService;
         table.setModel(model);
 
-        JButton btnRegistrarSalida = new JButton("Registrar retiro");
-        actionsPanel.add(btnRegistrarSalida, 0);
-        btnRegistrarSalida.addActionListener(e -> onRegistrarSalida());
+        styleActionsBar();
 
         // ---- Ordenamiento y filtro
         sorter = new TableRowSorter<>(table.getModel());
@@ -65,7 +64,7 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
                         0;
                     case "Nro" ->
                         1;
-                    case "Asunto" ->
+                    case "Solicitud" ->
                         2;
                     case "Estado" ->
                         3;
@@ -116,7 +115,7 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
         var cm = table.getColumnModel();
         cm.getColumn(0).setPreferredWidth(120); // ID
         cm.getColumn(1).setPreferredWidth(160); // Nro
-        cm.getColumn(2).setPreferredWidth(260); // Asunto
+        cm.getColumn(2).setPreferredWidth(260); // Solicitud
         cm.getColumn(3).setPreferredWidth(160); // Estado
         cm.getColumn(4).setPreferredWidth(180); // Fecha
         cm.getColumn(5).setPreferredWidth(220); // Solicitante
@@ -159,12 +158,61 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
         });
 
         // ---- Botón Cambiar estado
-        JButton btnEstado = new JButton("Cambiar estado");
-        ((JPanel) getContentPane().getComponent(0)).add(btnEstado);
-        btnEstado.addActionListener(e -> onEstado());
-
         // ---- Cargar
         loadData();
+    }
+
+    private void styleActionsBar() {
+        btnNuevo.setText("Registrar nueva solicitud");
+        btnEditar.setVisible(false);
+        btnBaja.setVisible(false);
+
+        stylePrimaryButton(btnNuevo);
+        styleOutlineButton(btnRefrescar);
+
+        JPanel top = (JPanel) ((BorderLayout) getContentPane().getLayout())
+                .getLayoutComponent(BorderLayout.NORTH);
+        top.removeAll();
+
+        actionsPanel.removeAll();
+        actionsPanel.setOpaque(false);
+        actionsPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 12, 10));
+        actionsPanel.add(btnNuevo);
+
+        JButton btnEstados = new JButton("Estados de solicitudes");
+        btnEstados.addActionListener(e -> onEstado());
+        styleOutlineButton(btnEstados);
+        actionsPanel.add(btnEstados);
+
+        btnRefrescar.setText("Refrescar");
+        actionsPanel.add(btnRefrescar);
+
+        top.setLayout(new BorderLayout());
+        top.add(actionsPanel, BorderLayout.CENTER);
+        top.revalidate();
+        top.repaint();
+    }
+
+    private static void stylePrimaryButton(AbstractButton b) {
+        b.setBackground(new Color(58, 96, 224));
+        b.setForeground(Color.WHITE);
+        b.setFont(b.getFont().deriveFont(Font.BOLD, 14f));
+        b.setFocusPainted(false);
+        b.setBorder(BorderFactory.createEmptyBorder(10, 16, 10, 16));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+    }
+
+    private static void styleOutlineButton(AbstractButton b) {
+        Color brand = new Color(58, 96, 224);
+        b.setBackground(Color.WHITE);
+        b.setForeground(brand);
+        b.setFont(b.getFont().deriveFont(Font.BOLD, 14f));
+        b.setFocusPainted(false);
+        b.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(brand, 1, true),
+                new EmptyBorder(9, 15, 9, 15)
+        ));
+        b.putClientProperty("JButton.buttonType", "roundRect");
     }
 
     @Override
@@ -181,15 +229,15 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
     protected void onNuevo() {
         Window owner = SwingUtilities.getWindowAncestor(this);
 
-        // Usa el constructor que realmente existe (Window, TramiteService)
-        RegistrarTramiteDialog dlg = new RegistrarTramiteDialog(owner, service);
+        // Usa el constructor que realmente existe (Window, TramiteService, InventarioService)
+        RegistrarTramiteDialog dlg = new RegistrarTramiteDialog(owner, service, invService);
         dlg.setVisible(true);
 
         if (!dlg.isAccepted()) {
             return;
         }
 
-        // 1) refresca la tabla local de Trámites
+        // 1) refresca la tabla local de Solicitudes
         loadData();
 
         // 2) avisa globalmente para que InformesPanel se recargue (métricas, movimientos, etc.)
@@ -206,12 +254,12 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
 
     @Override
     protected void onEditar() {
-        Ui.info(this, "Edición de campos no implementada (solo cambio de estado).");
+        Ui.info(this, "Edición de solicitudes no implementada (solo cambio de estado).");
     }
 
     @Override
     protected void onBaja() {
-        Ui.info(this, "No se implementa baja física de trámites.");
+        Ui.info(this, "No se implementa baja física de solicitudes.");
     }
 
     private void onEstado() {
@@ -235,22 +283,6 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
             } catch (Exception e) {
                 Ui.error(this, e);
             }
-        }
-    }
-
-    private void onRegistrarSalida() {
-        Window owner = SwingUtilities.getWindowAncestor(this);
-        RegistrarTramiteDialog dlg = new RegistrarTramiteDialog(owner, service);
-        if (!dlg.isReady()) {
-            return;
-        }
-        dlg.setVisible(true);
-        /*if (dlg.isAccepted()) {
-            loadData();
-        }*/
-        if (dlg.isAccepted()) {
-            loadData();                 // refresca la grilla local de trámites
-            UiBus.fire("tramite-saved"); // <- avisa globalmente a quien escuche (Informes)
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename the UI from Trámites to Solicitudes across navigation, forms, and metrics
- add a Solicitud registration dialog that supports multiple insumos with stock validation and automatic salida movements
- update services and reports to persist Solicitudes and refresh Informes after each save

## Testing
- mvn -q -DskipTests compile *(fails: Maven cannot download junit-bom 5.11.0)*

------
https://chatgpt.com/codex/tasks/task_e_6902b56b4e0883219b0f50f29dd18fa2