### PR TITLE
Update TramiteService tests for new registrar signature

### DIFF
--- a/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
+++ b/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
@@ -92,7 +92,12 @@ class TramiteServiceTest {
 
     @Test
     void registrarTramiteConMultiplesInsumos() throws Exception {
-        Long id = service.registrarNuevoTramite(List.of(
+        Long id = service.registrarNuevoTramite(
+                "Pedido de insumos de laboratorio",
+                "Informes",
+                "Reposición de materiales para prácticas",
+                "Laboratorio Central",
+                List.of(
                 new TramiteService.LineaTramite(1, 3),
                 new TramiteService.LineaTramite(2, 2)
         ));
@@ -136,7 +141,12 @@ class TramiteServiceTest {
     @Test
     void rollbackPorStockInsuficiente() {
         assertThrows(IllegalStateException.class, () ->
-                service.registrarNuevoTramite(List.of(new TramiteService.LineaTramite(2, 6))));
+                service.registrarNuevoTramite(
+                        "Solicitud extraordinaria",
+                        "Informes",
+                        "Pedido que excede el stock disponible",
+                        "Depósito",
+                        List.of(new TramiteService.LineaTramite(2, 6))));
 
         try (Connection cn = DataSourceFactory.getConnection(); Statement st = cn.createStatement()) {
             try (ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tramite")) {
@@ -150,7 +160,12 @@ class TramiteServiceTest {
 
     @Test
     void unificaLineasDuplicadas() throws Exception {
-        Long id = service.registrarNuevoTramite(List.of(
+        Long id = service.registrarNuevoTramite(
+                "Pedido de reposición",
+                "Informes",
+                "Unificación de pedidos repetidos",
+                "Laboratorio Central",
+                List.of(
                 new TramiteService.LineaTramite(1, 2),
                 new TramiteService.LineaTramite(1, 3)
         ));


### PR DESCRIPTION
## Summary
- update TramiteServiceTest invocations to provide the new registrarNuevoTramite parameters
- ensure the sample data keeps the previous assertions valid

## Testing
- mvn -q test *(fails: unable to resolve org.junit:junit-bom:5.11.0 due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6902c29c7a44832192871f666eb0bc4b