### PR TITLE
Update registrar dialog button labeling

### DIFF
--- a/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
@@ -23,7 +23,7 @@ public class RegistrarTramiteDialog extends JDialog {
     private final InventarioService inventarioService;
     private final JTable table = new JTable();
     private final LineaTableModel model = new LineaTableModel();
-    private final JButton btnGuardar = new JButton("Guardar");
+    private final JButton btnGuardar = new JButton("Registrar");
     private final JLabel lblTotales = new JLabel("0 ítems · 0 unidades");
     private boolean accepted = false;
     private final JTextField txtSolicitud = new JTextField(30);
@@ -51,7 +51,7 @@ public class RegistrarTramiteDialog extends JDialog {
         setLayout(new BorderLayout(10, 10));
         txtDescripcion.setLineWrap(true);
         txtDescripcion.setWrapStyleWord(true);
-        lblNumero.setText("Se generará al guardar");
+        lblNumero.setText("Se generará al registrar");
         lblNumero.setFont(lblNumero.getFont().deriveFont(Font.BOLD));
 
         add(buildFormPanel(), BorderLayout.NORTH);


### PR DESCRIPTION
## Summary
- rename the registrar dialog primary button to display "Registrar"
- adjust the auto-number hint to reference the registrar action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690392ca19ac8321b95fa62642cdb59b