### PR TITLE
Use AppLauncher for modern shell

### DIFF
--- a/src/main/java/ar/edu/unse/siga/ui/App.java
+++ b/src/main/java/ar/edu/unse/siga/ui/App.java
@@ -1,8 +1,6 @@
 package ar.edu.unse.siga.ui;
 
-
 import ar.edu.unse.siga.config.AppServices;
-import ar.edu.unse.siga.ui.shell.MainShellFrame;
 
 public class App {
     public static void main(String[] args) {
@@ -10,7 +8,7 @@ public class App {
         javax.swing.SwingUtilities.invokeLater(() -> {
             // inicializamos una vez los servicios
             AppServices.init();
-            new MainShellFrame().setVisible(true);
+            AppLauncher.launch();
         });
     }
 }


### PR DESCRIPTION
## Summary
- replace the legacy MainShellFrame instantiation with the modern AppLauncher entry point so the contemporary shell opens by default

## Testing
- not run (GUI application)


------
https://chatgpt.com/codex/tasks/task_e_6903af5c64908321b9e84e9821fe6350