### PR TITLE
Enable partial request handling and special orders

### DIFF
--- a/src/main/java/ar/edu/unse/siga/service/TramiteService.java
+++ b/src/main/java/ar/edu/unse/siga/service/TramiteService.java
@@ -13,7 +13,7 @@ import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,11 +45,11 @@ public class TramiteService {
     }
 
     // ==== Alta de solicitud con renglones ====
-    public Long registrarNuevoTramite(String solicitud,
-                                      String solicitante,
-                                      String descripcion,
-                                      String destino,
-                                      List<LineaTramite> lineas) {
+    public RegistroTramite registrarNuevoTramite(String solicitud,
+                                                 String solicitante,
+                                                 String descripcion,
+                                                 String destino,
+                                                 List<LineaTramite> lineas) {
         if (movimientoDao == null || insumoDao == null || tramiteDetalleDao == null) {
             throw new IllegalStateException("Dependencias no configuradas para registrar trámite con insumos");
         }
@@ -60,58 +60,60 @@ public class TramiteService {
             throw new IllegalArgumentException("Debe indicar al menos un insumo");
         }
 
-        // Consolidar cantidades por insumo y validar
-        LinkedHashMap<Long, BigDecimal> porInsumo = new LinkedHashMap<>();
-        for (LineaTramite l : lineas) {
-            if (l == null) throw new IllegalArgumentException("Línea inválida");
-            if (l.cantidad <= 0) throw new IllegalArgumentException("Cantidad inválida para insumo " + l.insumoId);
-            porInsumo.merge(l.insumoId, BigDecimal.valueOf(l.cantidad), BigDecimal::add);
-        }
-
-        // Normalizaciones
-        String nro = generarNumeroTramite();
-        String asunto = solicitud.trim();
+        String solicitudBase = solicitud.trim();
         String solicitanteFinal = (solicitante == null || solicitante.isBlank()) ? "Informes" : solicitante.trim();
         String destinoFinal = (destino == null || destino.isBlank()) ? "Secretaría FCEyT" : destino.trim();
         String descripcionFinal = (descripcion == null || descripcion.isBlank()) ? null : descripcion.trim();
+        String numeroBase = generarNumeroTramite();
+
+        List<Tramite> generados = new ArrayList<>();
+        int correlativo = 1;
 
         try (Connection cn = DataSourceFactory.getConnection()) {
             boolean originalAuto = cn.getAutoCommit();
             cn.setAutoCommit(false);
             try {
-                // Validar stock actual antes de tocar nada
-                for (var e : porInsumo.entrySet()) {
-                    long insumoId = e.getKey();
-                    BigDecimal cantidad = e.getValue();
+                for (LineaTramite linea : lineas) {
+                    if (linea == null) {
+                        throw new IllegalArgumentException("Línea inválida");
+                    }
+                    linea.validar();
+
+                    String numero = numeroBase + "-xxx" + correlativo++;
+                    String nombreItem = linea.getNombre();
+                    String asuntoFinal = solicitudBase;
+                    if (nombreItem != null && !nombreItem.isBlank()) {
+                        asuntoFinal = solicitudBase.isBlank()
+                                ? nombreItem.trim()
+                                : solicitudBase + " - " + nombreItem.trim();
+                    }
+
+                    Tramite tramite = new Tramite();
+                    tramite.setNro(numero);
+                    tramite.setAsunto(asuntoFinal);
+                    tramite.setSolicitante(solicitanteFinal);
+                    tramite.setDescripcion(descripcionFinal);
+                    tramite.setDestino(destinoFinal);
+                    tramite.setFecha(LocalDateTime.now());
+
+                    if (linea.esEspecial()) {
+                        tramite.setEstado("PENDIENTE");
+                        Long id = tramiteDao.create(tramite, cn);
+                        tramite.setId(id);
+                        generados.add(tramite);
+                        continue;
+                    }
+
+                    long insumoId = linea.getInsumoId();
+                    BigDecimal cantidad = BigDecimal.valueOf(linea.getCantidad());
                     BigDecimal actual = movimientoDao.stockActual(insumoId);
-                    if (actual.compareTo(cantidad) < 0) {
-                        throw new IllegalStateException("Stock insuficiente para el insumo " + insumoId);
-                    }
-                }
+                    boolean hayStock = actual != null && actual.compareTo(cantidad) >= 0;
 
-                // Crear trámite
-                Tramite tramite = new Tramite();
-                tramite.setNro(nro);
-                tramite.setAsunto(asunto);
-                tramite.setSolicitante(solicitanteFinal);
-                tramite.setDescripcion(descripcionFinal);
-                tramite.setDestino(destinoFinal);
-                tramite.setEstado("NUEVO");
-                tramite.setFecha(LocalDateTime.now());
-                Long tramiteId = tramiteDao.create(tramite, cn);
+                    tramite.setEstado(hayStock ? "COMPLETADO" : "PENDIENTE");
+                    Long tramiteId = tramiteDao.create(tramite, cn);
+                    tramite.setId(tramiteId);
+                    generados.add(tramite);
 
-                // Por cada insumo: descontar stock, crear detalle y movimiento (SALIDA)
-                for (var e : porInsumo.entrySet()) {
-                    long insumoId = e.getKey();
-                    BigDecimal cantidad = e.getValue();
-
-                    // Descontar stock (optimista, con chequeo de cambio)
-                    boolean ok = insumoDao.decrementStock(cn, insumoId, cantidad);
-                    if (!ok) {
-                        throw new IllegalStateException("El stock cambió. Revisá cantidades e intentá nuevamente.");
-                    }
-
-                    // Detalle
                     TramiteDetalle det = new TramiteDetalle();
                     det.setTramiteId(tramiteId);
                     Insumo ins = new Insumo();
@@ -120,15 +122,20 @@ public class TramiteService {
                     det.setCantidad(cantidad);
                     tramiteDetalleDao.create(det, cn);
 
-                    // Movimiento SALIDA (observación: el DAO actual no recibe 'destino')
-                    movimientoDao.registrarSalida(cn, insumoId, cantidad, solicitanteFinal, tramiteId);
+                    if (hayStock) {
+                        boolean ok = insumoDao.decrementStock(cn, insumoId, cantidad);
+                        if (!ok) {
+                            throw new IllegalStateException("El stock cambió. Revisá cantidades e intentá nuevamente.");
+                        }
+                        movimientoDao.registrarSalida(cn, insumoId, cantidad, solicitanteFinal, tramiteId);
+                    }
                 }
 
                 cn.commit();
-                return tramiteId;
+                return new RegistroTramite(numeroBase, generados);
             } catch (Exception e) {
                 try { cn.rollback(); } catch (SQLException ignored) {}
-                if (e instanceof IllegalStateException) throw e; // mensaje claro al usuario
+                if (e instanceof IllegalStateException) throw e;
                 throw new RuntimeException("No se pudo registrar la solicitud", e);
             } finally {
                 try { cn.setAutoCommit(originalAuto); } catch (SQLException ignored) {}
@@ -146,10 +153,59 @@ public class TramiteService {
 
     // DTO interno para la UI
     public static class LineaTramite {
-        private final long insumoId;
+        private final Long insumoId;
+        private final String nombre;
         private final int cantidad;
-        public LineaTramite(long insumoId, int cantidad) { this.insumoId = insumoId; this.cantidad = cantidad; }
-        public long getInsumoId() { return insumoId; }
+        private final boolean especial;
+
+        public LineaTramite(long insumoId, int cantidad) {
+            this(insumoId, null, cantidad, false);
+        }
+
+        public LineaTramite(Long insumoId, String nombre, int cantidad, boolean especial) {
+            this.insumoId = insumoId;
+            this.nombre = nombre;
+            this.cantidad = cantidad;
+            this.especial = especial;
+        }
+
+        public static LineaTramite deInsumo(long insumoId, String nombre, int cantidad) {
+            return new LineaTramite(insumoId, nombre, cantidad, false);
+        }
+
+        public static LineaTramite pedidoEspecial(String nombre, int cantidad) {
+            return new LineaTramite(null, nombre, cantidad, true);
+        }
+
+        public void validar() {
+            if (cantidad <= 0) {
+                throw new IllegalArgumentException("Cantidad inválida para la línea");
+            }
+            if (especial) {
+                if (nombre == null || nombre.isBlank()) {
+                    throw new IllegalArgumentException("El pedido especial debe tener un nombre");
+                }
+            } else if (insumoId == null || insumoId <= 0) {
+                throw new IllegalArgumentException("La línea debe referenciar un insumo válido");
+            }
+        }
+
+        public Long getInsumoId() { return insumoId; }
+        public String getNombre() { return nombre; }
         public int getCantidad() { return cantidad; }
+        public boolean esEspecial() { return especial; }
+    }
+
+    public static class RegistroTramite {
+        private final String numeroBase;
+        private final List<Tramite> tramites;
+
+        public RegistroTramite(String numeroBase, List<Tramite> tramites) {
+            this.numeroBase = numeroBase;
+            this.tramites = List.copyOf(tramites);
+        }
+
+        public String getNumeroBase() { return numeroBase; }
+        public List<Tramite> getTramites() { return tramites; }
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/HomePage.java
@@ -445,12 +445,12 @@ public class HomePage extends JPanel {
             case "COMPLETADO":
             case "CERRADO":
                 return "Completado";
-            case "EN_PROCESO":
-                return "En proceso";
-            case "ALTA":
-                return "Alta";
             case "PENDIENTE":
                 return "Pendiente";
+            case "RECHAZADO":
+                return "Rechazado";
+            case "ALTA":
+                return "Alta";
             default:
                 return capitalize(estado);
         }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -44,7 +44,7 @@ public class TramiteEntradaPage extends JPanel {
     // --- Filtros de la tabla ---
     private final JTextField filterSearch = new JTextField(18);
     private final JComboBox<String> filterEstado = new JComboBox<>(
-            new String[]{"Todos", "Completado", "En proceso", "Pendiente", "Nuevo"}
+            new String[]{"Todos", "Completado", "Pendiente", "Rechazado"}
     );
 
     private final CardLayout cardLayout = new CardLayout();
@@ -55,7 +55,7 @@ public class TramiteEntradaPage extends JPanel {
     // Tabla (solo columna Estado editable)
     private final JTable table = new JTable(new DefaultTableModel(
             new Object[][]{},
-            new String[]{"ID Solicitud", "Solicitud", "Fecha creación", "Última actualización", "Descripcion", "Estado"}
+            new String[]{"ID Solicitud", "Solicitud", "Fecha de solicitud", "Fecha de atención", "Descripción", "Estado"}
     )) {
         @Override
         public boolean isCellEditable(int row, int column) {
@@ -96,7 +96,7 @@ public class TramiteEntradaPage extends JPanel {
         SwingUtilities.invokeLater(() -> {
             try {
                 if (table.getColumnCount() > 5) {
-                    String[] estados = {"PENDIENTE", "EN PROCESO", "COMPLETADO"};
+                    String[] estados = {"PENDIENTE", "COMPLETADO", "RECHAZADO"};
                     JComboBox<String> comboEstado = new JComboBox<>(estados);
                     table.getColumnModel().getColumn(5).setCellEditor(new DefaultCellEditor(comboEstado));
                     if (table.getRowHeight() < 28) table.setRowHeight(28);
@@ -116,9 +116,9 @@ public class TramiteEntradaPage extends JPanel {
                 try {
                     String elegido = String.valueOf(table.getValueAt(row, col)).trim().toUpperCase(Locale.ROOT);
                     String canon = switch (elegido) {
-                        case "EN PROCESO" -> "EN_PROCESO";
                         case "COMPLETADO" -> "COMPLETADO";
                         case "PENDIENTE"  -> "PENDIENTE";
+                        case "RECHAZADO" -> "RECHAZADO";
                         default -> elegido;
                     };
 
@@ -153,8 +153,8 @@ public class TramiteEntradaPage extends JPanel {
         header.add(title, BorderLayout.WEST);
 
         ButtonGroup tabs = new ButtonGroup();
-        tabRegistrar = tabButton("Registrar nueva solicitud");
-        tabActivos   = tabButton("Estados de solicitudes");
+        tabRegistrar = tabButton("Nueva solicitud");
+        tabActivos   = tabButton("Atención de solicitudes");
         tabs.add(tabRegistrar);
         tabs.add(tabActivos);
         tabRegistrar.setSelected(true);
@@ -216,7 +216,7 @@ public class TramiteEntradaPage extends JPanel {
         gbc.gridy = 0;
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 16, 0);
-        JLabel title = new JLabel("Registrar nueva solicitud");
+        JLabel title = new JLabel("Nueva solicitud");
         title.setFont(new Font("Segoe UI", Font.BOLD, 18));
         title.setForeground(new Color(54, 92, 190));
         panel.add(title, gbc);
@@ -240,7 +240,7 @@ public class TramiteEntradaPage extends JPanel {
         gbc.weighty = 1;
         panel.add(description, gbc);
 
-        JButton btn = primaryButton("Registrar nueva solicitud");
+        JButton btn = primaryButton("Nueva solicitud");
         btn.addActionListener(e -> openRegistrarDialog());
         btn.setAlignmentX(Component.LEFT_ALIGNMENT);
 
@@ -331,8 +331,9 @@ public class TramiteEntradaPage extends JPanel {
                 String badgeTxt = estadoFriendly(t.getEstado());
                 Color badgeColor = switch (badgeTxt.toLowerCase(Locale.ROOT)) {
                     case "completado" -> new Color(73, 198, 154);
-                    case "en proceso" -> new Color(86, 127, 255);
-                    default -> new Color(255, 170, 70);
+                    case "rechazado" -> new Color(225, 95, 95);
+                    case "pendiente" -> new Color(255, 170, 70);
+                    default -> new Color(86, 127, 255);
                 };
 
                 Component item = recentItem(solicitudTxt, estado, badgeTxt, badgeColor);
@@ -443,12 +444,18 @@ public class TramiteEntradaPage extends JPanel {
                     continue;
                 }
 
-                String fecha = t.getFecha() != null ? t.getFecha().format(fmt) : "-";
-                String ultima = t.getFecha() != null ? t.getFecha().format(fmt) : "-"; // si tenés un campo real, usalo acá
+                String fechaSolicitud = t.getFecha() != null ? t.getFecha().format(fmt) : "-";
+                String fechaAtencion = "-";
+                if (t.getEstado() != null) {
+                    String upper = t.getEstado().toUpperCase(Locale.ROOT);
+                    if (!"PENDIENTE".equals(upper)) {
+                        fechaAtencion = fechaSolicitud;
+                    }
+                }
                 String descripcion = (t.getDescripcion() == null || t.getDescripcion().isBlank()) ? "-" : t.getDescripcion();
                 String estado = estadoFriendly(t.getEstado());
 
-                model.addRow(new Object[]{ t.getNro(), t.getAsunto(), fecha, ultima, descripcion, estado });
+                model.addRow(new Object[]{ t.getNro(), t.getAsunto(), fechaSolicitud, fechaAtencion, descripcion, estado });
 
                 currentRows.add(t);
             }
@@ -489,9 +496,9 @@ public class TramiteEntradaPage extends JPanel {
         if (estado == null) return "Pendiente";
         return switch (estado.toUpperCase(Locale.ROOT)) {
             case "COMPLETADO", "CERRADO" -> "Completado";
-            case "EN_PROCESO" -> "En proceso";
-            case "ALTA" -> "Alta";
             case "PENDIENTE" -> "Pendiente";
+            case "RECHAZADO" -> "Rechazado";
+            case "ALTA" -> "Alta";
             default -> capitalize(estado);
         };
     }
@@ -597,9 +604,10 @@ public class TramiteEntradaPage extends JPanel {
                 else                                    base = new Color(200, 210, 230);
             } else {
                 if (normalized.contains("complet"))     base = new Color(73, 198, 154);
-                else if (normalized.contains("proceso"))base = new Color(86, 127, 255);
+                else if (normalized.contains("rechaz")) base = new Color(225, 95, 95);
+                else if (normalized.contains("pend"))  base = new Color(255, 188, 75);
                 else if (normalized.contains("alta"))   base = new Color(255, 120, 102);
-                else                                     base = new Color(255, 188, 75);
+                else                                     base = new Color(86, 127, 255);
             }
 
             if (isSelected) {

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/RegistrarTramiteDialog.java
@@ -1,26 +1,22 @@
 package ar.edu.unse.siga.ui.tramites;
 
 import ar.edu.unse.siga.domain.Insumo;
+import ar.edu.unse.siga.domain.Ubicacion;
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.ui.base.Ui;
-import ar.edu.unse.siga.persistence.DataSourceFactory;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
 import java.awt.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Comparator;
 import java.util.List;
 
 public class RegistrarTramiteDialog extends JDialog {
@@ -47,12 +43,12 @@ public class RegistrarTramiteDialog extends JDialog {
         super(owner, "Registrar solicitud", ModalityType.APPLICATION_MODAL);
         this.tramiteService = tramiteService;
         this.inventarioService = inventarioService;
-        this.insumosDisponibles = new ArrayList<>(inventarioService.insumosConStockDisponible());
-        this.ready = !insumosDisponibles.isEmpty();
-
-        if (!ready) {
-            Ui.warn(this, "No hay insumos con stock disponible para registrar.");
-        }
+        this.insumosDisponibles = new ArrayList<>(inventarioService.listarTodos());
+        this.insumosDisponibles.removeIf(i -> i == null || (i.getEstado() != null
+                && i.getEstado().equalsIgnoreCase("INACTIVO")));
+        this.insumosDisponibles.sort(Comparator.comparing(this::labelForInsumo,
+                String.CASE_INSENSITIVE_ORDER));
+        this.ready = true;
 
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         setLayout(new BorderLayout(10, 10));
@@ -74,29 +70,10 @@ public class RegistrarTramiteDialog extends JDialog {
         table.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         table.setFillsViewportHeight(true);
 
-        // Editor para seleccionar Insumo
-        table.getColumnModel().getColumn(0).setCellEditor(new InsumoCellEditor());
+        // Editor para seleccionar o escribir el nombre
+        table.getColumnModel().getColumn(0).setCellEditor(new NombreCellEditor());
         // Editor de cantidad
         table.getColumnModel().getColumn(2).setCellEditor(new CantidadCellEditor());
-
-        // Renderer que muestra "codigo - descripcion" para Insumo
-        table.setDefaultRenderer(Insumo.class, new DefaultTableCellRenderer() {
-            @Override public void setValue(Object value) {
-                if (value instanceof Insumo) {
-                    Insumo i = (Insumo) value;
-                    String codigo = i.getCodigo() == null ? "" : i.getCodigo().trim();
-                    String desc   = i.getDescripcion() == null ? "" : i.getDescripcion().trim();
-                    String label;
-                    if (!codigo.isEmpty() && !desc.isEmpty())      label = codigo + " - " + desc;
-                    else if (!codigo.isEmpty())                    label = codigo;
-                    else if (!desc.isEmpty())                      label = desc;
-                    else                                           label = "";
-                    setText(label);
-                } else {
-                    setText("");
-                }
-            }
-        });
 
         add(new JScrollPane(table), BorderLayout.CENTER);
 
@@ -107,8 +84,10 @@ public class RegistrarTramiteDialog extends JDialog {
 
         JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton btnAgregar = new JButton("Agregar renglón");
+        JButton btnPedidoEspecial = new JButton("Agregar pedido especial");
         JButton btnQuitar = new JButton("Quitar renglón");
         right.add(btnAgregar);
+        right.add(btnPedidoEspecial);
         right.add(btnQuitar);
         right.add(btnRegistrar);
         south.add(right, BorderLayout.EAST);
@@ -118,6 +97,7 @@ public class RegistrarTramiteDialog extends JDialog {
             model.addEmptyRow();
             actualizarTotales();
         });
+        btnPedidoEspecial.addActionListener(e -> onAgregarPedidoEspecial());
         btnQuitar.addActionListener(e -> {
             int row = table.getSelectedRow();
             if (row >= 0) {
@@ -196,14 +176,25 @@ public class RegistrarTramiteDialog extends JDialog {
         }
 
         try {
-            Long id = tramiteService.registrarNuevoTramite(
+            TramiteService.RegistroTramite resultado = tramiteService.registrarNuevoTramite(
                     solicitud,
                     solicitante.isEmpty() ? null : solicitante,
                     descripcion.isEmpty() ? null : descripcion,
                     destino,
                     lineas
             );
-            Ui.info(this, "Solicitud registrada. ID: " + id);
+
+            StringBuilder info = new StringBuilder();
+            info.append("Solicitudes registradas (base ")
+                    .append(resultado.getNumeroBase())
+                    .append("):\n");
+            resultado.getTramites().forEach(t -> info.append("• #")
+                    .append(t.getNro())
+                    .append(" · ")
+                    .append(t.getEstado())
+                    .append('\n'));
+
+            Ui.info(this, info.toString());
             accepted = true;
             dispose();
         } catch (IllegalStateException ex) {
@@ -220,54 +211,76 @@ public class RegistrarTramiteDialog extends JDialog {
         lblTotales.setText(filas + " ítems · " + unidades + " unidades");
     }
 
+    private void onAgregarPedidoEspecial() {
+        String nombre = JOptionPane.showInputDialog(this,
+                "Detalle del pedido especial:",
+                "Agregar pedido especial",
+                JOptionPane.PLAIN_MESSAGE);
+        if (nombre == null) {
+            return;
+        }
+        String cleaned = nombre.trim();
+        if (cleaned.isEmpty()) {
+            Ui.warn(this, "Ingresá un nombre para el pedido especial.");
+            return;
+        }
+        model.addPedidoEspecial(cleaned);
+        actualizarTotales();
+    }
+
+    private String labelForInsumo(Insumo insumo) {
+        if (insumo == null) {
+            return "";
+        }
+        String codigo = insumo.getCodigo() == null ? "" : insumo.getCodigo().trim();
+        String desc = insumo.getDescripcion() == null ? "" : insumo.getDescripcion().trim();
+        if (!codigo.isEmpty() && !desc.isEmpty()) {
+            return codigo + " - " + desc;
+        }
+        if (!codigo.isEmpty()) {
+            return codigo;
+        }
+        return desc;
+    }
+
     private void loadDestinosPredefinidos() {
-        // Busca destinos existentes en 'movimiento.destino_fuente' para SALIDA
-        LinkedHashSet<String> set = new LinkedHashSet<>();
-        final String sql = """
-            SELECT DISTINCT destino_fuente
-            FROM movimiento
-            WHERE tipo='SALIDA' AND destino_fuente IS NOT NULL AND TRIM(destino_fuente) <> ''
-            ORDER BY destino_fuente
-            """;
-        try (Connection cn = DataSourceFactory.getConnection();
-             PreparedStatement ps = cn.prepareStatement(sql);
-             ResultSet rs = ps.executeQuery()) {
-            while (rs.next()) {
-                String d = rs.getString(1);
-                if (d != null && !d.isBlank()) set.add(d.trim());
-            }
-        } catch (Exception ignored) {
-            // si falla, seguimos con defaults
-        }
-        if (set.isEmpty()) {
-            set.add("Secretaría FCEyT");
-            set.add("Compras");
-            set.add("Finanzas");
-            set.add("Mantenimiento");
-        }
         cboDestino.removeAllItems();
-        for (String d : set) cboDestino.addItem(d);
+        if (inventarioService != null) {
+            List<Ubicacion> ubicaciones = inventarioService.listarUbicaciones();
+            ubicaciones.stream()
+                    .map(Ubicacion::getNombre)
+                    .filter(n -> n != null && !n.isBlank())
+                    .distinct()
+                    .forEach(cboDestino::addItem);
+        }
+        if (cboDestino.getItemCount() == 0) {
+            cboDestino.addItem("Secretaría FCEyT");
+            cboDestino.addItem("Compras");
+            cboDestino.addItem("Finanzas");
+            cboDestino.addItem("Mantenimiento");
+        }
         cboDestino.setSelectedIndex(0);
     }
 
     private int stockDisponible(Insumo insumo) {
-        if (insumo == null) return 0;
-        BigDecimal stock = insumo.getStockActual();
+        if (insumo == null || insumo.getId() == null || inventarioService == null) return 0;
+        BigDecimal stock = inventarioService.stockActualExacto(insumo.getId());
         if (stock == null) return 0;
-        return stock.setScale(0, RoundingMode.FLOOR).intValue();
+        return stock.setScale(0, RoundingMode.DOWN).intValue();
     }
 
     // ======= Tabla de líneas =======
     private class LineaTableModel extends AbstractTableModel {
-        private final String[] cols = {"Insumo", "Stock disponible", "Cantidad"};
+        private final String[] cols = {"Nombre", "Stock disponible", "Cantidad"};
         private final List<Fila> filas = new ArrayList<>();
 
         void addEmptyRow() {
-            if (filas.size() >= insumosDisponibles.size()) {
-                Ui.warn(RegistrarTramiteDialog.this, "Ya agregaste todos los insumos disponibles.");
-                return;
-            }
-            filas.add(new Fila(null, 1));
+            filas.add(new Fila(null, null, 1));
+            fireTableRowsInserted(filas.size() - 1, filas.size() - 1);
+        }
+
+        void addPedidoEspecial(String descripcion) {
+            filas.add(new Fila(null, descripcion, 1));
             fireTableRowsInserted(filas.size() - 1, filas.size() - 1);
         }
 
@@ -280,9 +293,18 @@ public class RegistrarTramiteDialog extends JDialog {
 
         boolean isValidRows() {
             for (Fila f : filas) {
-                if (f.insumo == null) return false;
-                if (f.cantidad <= 0) return false;
-                if (f.cantidad > stockDisponible(f.insumo)) return false;
+                if (f.esPedidoEspecial()) {
+                    if (f.especial == null || f.especial.isBlank()) {
+                        return false;
+                    }
+                } else {
+                    if (f.insumo == null) {
+                        return false;
+                    }
+                }
+                if (f.cantidad <= 0) {
+                    return false;
+                }
             }
             return true;
         }
@@ -290,8 +312,13 @@ public class RegistrarTramiteDialog extends JDialog {
         List<TramiteService.LineaTramite> toLineas() {
             List<TramiteService.LineaTramite> list = new ArrayList<>();
             for (Fila f : filas) {
-                if (f.insumo != null && f.cantidad > 0) {
-                    list.add(new TramiteService.LineaTramite(f.insumo.getId(), f.cantidad));
+                if (f.cantidad <= 0) {
+                    continue;
+                }
+                if (f.esPedidoEspecial()) {
+                    list.add(TramiteService.LineaTramite.pedidoEspecial(f.especial, f.cantidad));
+                } else if (f.insumo != null) {
+                    list.add(TramiteService.LineaTramite.deInsumo(f.insumo.getId(), labelForInsumo(f.insumo), f.cantidad));
                 }
             }
             return list;
@@ -303,55 +330,82 @@ public class RegistrarTramiteDialog extends JDialog {
             return sum;
         }
 
+        boolean isPedidoEspecial(int row) {
+            if (row < 0 || row >= filas.size()) return false;
+            return filas.get(row).esPedidoEspecial();
+        }
+
+        String getEspecialDescripcion(int row) {
+            if (row < 0 || row >= filas.size()) return "";
+            String texto = filas.get(row).especial;
+            return texto == null ? "" : texto;
+        }
+
+        Insumo getInsumo(int row) {
+            if (row < 0 || row >= filas.size()) return null;
+            return filas.get(row).insumo;
+        }
+
         @Override public int getRowCount() { return filas.size(); }
         @Override public int getColumnCount() { return cols.length; }
         @Override public String getColumnName(int column) { return cols[column]; }
+        @Override public Class<?> getColumnClass(int columnIndex) {
+            return switch (columnIndex) {
+                case 2 -> Integer.class;
+                default -> String.class;
+            };
+        }
 
         @Override
         public Object getValueAt(int rowIndex, int columnIndex) {
             Fila f = filas.get(rowIndex);
-            switch (columnIndex) {
-                case 0: return f.insumo;
-                case 1: return f.insumo == null ? 0 : stockDisponible(f.insumo);
-                case 2: return f.cantidad;
-            }
-            return null;
+            return switch (columnIndex) {
+                case 0 -> f.esPedidoEspecial() ? f.especial : labelForInsumo(f.insumo);
+                case 1 -> f.esPedidoEspecial() ? "-" : String.valueOf(stockDisponible(f.insumo));
+                case 2 -> f.cantidad;
+                default -> null;
+            };
         }
 
         @Override
-        public boolean isCellEditable(int rowIndex, int columnIndex) { return columnIndex != 1; }
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return columnIndex != 1;
+        }
 
         @Override
         public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
             Fila f = filas.get(rowIndex);
-            if (columnIndex == 0 && aValue instanceof Insumo) {
-                Insumo nuevo = (Insumo) aValue;
-                // evitar duplicados
-                for (int i = 0; i < filas.size(); i++) {
-                    if (i != rowIndex && filas.get(i).insumo != null
-                            && filas.get(i).insumo.getId().equals(nuevo.getId())) {
-                        Ui.warn(RegistrarTramiteDialog.this, "Ese insumo ya fue agregado.");
-                        fireTableRowsUpdated(rowIndex, rowIndex);
+            if (columnIndex == 0) {
+                if (aValue instanceof Insumo) {
+                    Insumo nuevo = (Insumo) aValue;
+                    for (int i = 0; i < filas.size(); i++) {
+                        if (i != rowIndex && filas.get(i).insumo != null
+                                && filas.get(i).insumo.getId().equals(nuevo.getId())) {
+                            Ui.warn(RegistrarTramiteDialog.this, "Ese insumo ya fue agregado.");
+                            fireTableRowsUpdated(rowIndex, rowIndex);
+                            return;
+                        }
+                    }
+                    f.insumo = nuevo;
+                    f.especial = null;
+                    if (f.cantidad <= 0) f.cantidad = 1;
+                    fireTableRowsUpdated(rowIndex, rowIndex);
+                } else if (aValue != null) {
+                    String texto = String.valueOf(aValue).trim();
+                    if (texto.isEmpty()) {
+                        Ui.warn(RegistrarTramiteDialog.this, "Ingresá un nombre válido.");
                         return;
                     }
+                    f.especial = texto;
+                    f.insumo = null;
+                    if (f.cantidad <= 0) f.cantidad = 1;
+                    fireTableRowsUpdated(rowIndex, rowIndex);
                 }
-                int max = stockDisponible(nuevo);
-                if (max <= 0) {
-                    Ui.warn(RegistrarTramiteDialog.this, "El insumo seleccionado no tiene stock disponible.");
-                    return;
-                }
-                f.insumo = nuevo;
-                if (f.cantidad <= 0) f.cantidad = 1;
-                fireTableRowsUpdated(rowIndex, rowIndex);
             } else if (columnIndex == 2) {
                 try {
                     int val = Integer.parseInt(String.valueOf(aValue));
                     if (val <= 0) {
                         Ui.warn(RegistrarTramiteDialog.this, "Cantidad inválida.");
-                        return;
-                    }
-                    if (f.insumo != null && val > stockDisponible(f.insumo)) {
-                        Ui.warn(RegistrarTramiteDialog.this, "No hay stock suficiente.");
                         return;
                     }
                     f.cantidad = val;
@@ -364,45 +418,72 @@ public class RegistrarTramiteDialog extends JDialog {
 
         class Fila {
             Insumo insumo;
+            String especial;
             int cantidad;
-            Fila(Insumo i, int c) { this.insumo = i; this.cantidad = c; }
+            Fila(Insumo i, String especial, int c) { this.insumo = i; this.especial = especial; this.cantidad = c; }
+            boolean esPedidoEspecial() { return especial != null && !especial.isBlank(); }
         }
     }
 
     // ======= Editores =======
-    private class InsumoCellEditor extends AbstractCellEditor implements TableCellEditor {
+    private class NombreCellEditor extends AbstractCellEditor implements TableCellEditor {
         private final JComboBox<Insumo> combo = new JComboBox<>();
-        public InsumoCellEditor() {
+        private final JTextField textField = new JTextField();
+        private boolean modoEspecial = false;
+
+        public NombreCellEditor() {
             for (Insumo i : insumosDisponibles) combo.addItem(i);
-            // Renderer del combo: "codigo - descripcion"
             combo.setRenderer(new DefaultListCellRenderer() {
                 @Override
                 public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
                     Component c = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                     if (value instanceof Insumo) {
-                        Insumo i = (Insumo) value;
-                        String codigo = i.getCodigo() == null ? "" : i.getCodigo().trim();
-                        String desc   = i.getDescripcion() == null ? "" : i.getDescripcion().trim();
-                        String label = (!codigo.isEmpty() && !desc.isEmpty()) ? (codigo + " - " + desc)
-                                     : (!codigo.isEmpty() ? codigo : desc);
-                        setText(label);
+                        setText(labelForInsumo((Insumo) value));
                     }
                     return c;
                 }
             });
+            textField.setBorder(BorderFactory.createEmptyBorder(0, 6, 0, 6));
         }
-        @Override public Object getCellEditorValue() { return combo.getSelectedItem(); }
+
+        @Override public Object getCellEditorValue() {
+            if (modoEspecial) {
+                return textField.getText();
+            }
+            return combo.getSelectedItem();
+        }
+
         @Override public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
-            if (value instanceof Insumo) combo.setSelectedItem(value);
+            modoEspecial = model.isPedidoEspecial(row);
+            if (modoEspecial) {
+                textField.setText(model.getEspecialDescripcion(row));
+                SwingUtilities.invokeLater(textField::selectAll);
+                return textField;
+            }
+            Insumo actual = model.getInsumo(row);
+            if (actual != null) {
+                combo.setSelectedItem(actual);
+            }
             return combo;
         }
     }
 
     private class CantidadCellEditor extends AbstractCellEditor implements TableCellEditor {
         private final JTextField field = new JTextField();
+
+        private CantidadCellEditor() {
+            field.setHorizontalAlignment(JTextField.RIGHT);
+            field.setBorder(BorderFactory.createEmptyBorder(0, 6, 0, 6));
+            field.setForeground(Color.BLACK);
+            field.setBackground(Color.WHITE);
+            field.setCaretColor(Color.BLACK);
+        }
+
         @Override public Object getCellEditorValue() { return field.getText(); }
+
         @Override public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
             field.setText(value == null ? "1" : String.valueOf(value));
+            SwingUtilities.invokeLater(field::selectAll);
             return field;
         }
     }

--- a/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/tramites/TramiteFrame.java
@@ -163,7 +163,7 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
     }
 
     private void styleActionsBar() {
-        btnNuevo.setText("Registrar nueva solicitud");
+        btnNuevo.setText("Nueva solicitud");
         btnEditar.setVisible(false);
         btnBaja.setVisible(false);
 
@@ -179,7 +179,7 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
         actionsPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 12, 10));
         actionsPanel.add(btnNuevo);
 
-        JButton btnEstados = new JButton("Estados de solicitudes");
+        JButton btnEstados = new JButton("Atención de solicitudes");
         btnEstados.addActionListener(e -> onEstado());
         styleOutlineButton(btnEstados);
         actionsPanel.add(btnEstados);
@@ -274,7 +274,7 @@ public class TramiteFrame extends BaseCrudFrame<Tramite> {
         String nuevo = (String) JOptionPane.showInputDialog(this,
                 "Nuevo estado:", "Cambiar estado",
                 JOptionPane.PLAIN_MESSAGE, null,
-                new String[]{"PENDIENTE", "EN_PROCESO", "COMPLETADO", "CERRADO"},
+                new String[]{"PENDIENTE", "COMPLETADO", "RECHAZADO", "CERRADO"},
                 sel.getEstado());
         if (nuevo != null) {
             try {

--- a/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
+++ b/src/test/java/ar/edu/unse/siga/service/TramiteServiceTest.java
@@ -1,5 +1,6 @@
 package ar.edu.unse.siga.service;
 
+import ar.edu.unse.siga.domain.Tramite;
 import ar.edu.unse.siga.persistence.DataSourceFactory;
 import ar.edu.unse.siga.persistence.dao.InsumoDao;
 import ar.edu.unse.siga.persistence.dao.MovimientoDao;
@@ -91,44 +92,67 @@ class TramiteServiceTest {
     }
 
     @Test
-    void registrarTramiteConMultiplesInsumos() throws Exception {
-        Long id = service.registrarNuevoTramite(
+    void registroParcialGeneraSolicitudesCompletadasYPendientes() throws Exception {
+        TramiteService.RegistroTramite resultado = service.registrarNuevoTramite(
                 "Entrega de insumos",
                 "Informes",
                 "Reposición semanal",
                 "Mesa de entradas",
                 List.of(
-                        new TramiteService.LineaTramite(1, 3),
-                        new TramiteService.LineaTramite(2, 2)
+                        TramiteService.LineaTramite.deInsumo(1, "Insumo A", 3),
+                        TramiteService.LineaTramite.deInsumo(2, "Insumo B", 6)
                 )
         );
 
-        assertNotNull(id);
+        assertEquals(2, resultado.getTramites().size());
+        assertNotNull(resultado.getNumeroBase());
+        assertTrue(resultado.getTramites().stream()
+                .allMatch(t -> t.getNro() != null && t.getNro().startsWith(resultado.getNumeroBase())));
+
+        Tramite completado = resultado.getTramites().stream()
+                .filter(t -> "COMPLETADO".equals(t.getEstado()))
+                .findFirst()
+                .orElseThrow();
+        Tramite pendiente = resultado.getTramites().stream()
+                .filter(t -> "PENDIENTE".equals(t.getEstado()))
+                .findFirst()
+                .orElseThrow();
 
         try (Connection cn = DataSourceFactory.getConnection()) {
-            try (PreparedStatement ps = cn.prepareStatement("SELECT solicitante FROM tramite WHERE id=?")) {
-                ps.setLong(1, id);
-                try (ResultSet rs = ps.executeQuery()) {
-                    assertTrue(rs.next());
-                    assertEquals("Informes", rs.getString(1));
-                }
-            }
-
-            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
-                ps.setLong(1, id);
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite")) {
                 try (ResultSet rs = ps.executeQuery()) {
                     assertTrue(rs.next());
                     assertEquals(2, rs.getInt(1));
                 }
             }
 
-            try (PreparedStatement ps = cn.prepareStatement("SELECT cantidad FROM movimiento WHERE tramite_id=? ORDER BY insumo_id")) {
-                ps.setLong(1, id);
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
+                ps.setLong(1, completado.getId());
                 try (ResultSet rs = ps.executeQuery()) {
                     assertTrue(rs.next());
-                    assertEquals(3, rs.getBigDecimal(1).intValue());
+                    assertEquals(1, rs.getInt(1));
+                }
+            }
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
+                ps.setLong(1, pendiente.getId());
+                try (ResultSet rs = ps.executeQuery()) {
                     assertTrue(rs.next());
-                    assertEquals(2, rs.getBigDecimal(1).intValue());
+                    assertEquals(1, rs.getInt(1));
+                }
+            }
+
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM movimiento WHERE tramite_id=?")) {
+                ps.setLong(1, completado.getId());
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(1, rs.getInt(1));
+                }
+            }
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM movimiento WHERE tramite_id=?")) {
+                ps.setLong(1, pendiente.getId());
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(0, rs.getInt(1));
                 }
             }
 
@@ -136,57 +160,41 @@ class TramiteServiceTest {
                 assertTrue(rs.next());
                 assertEquals(7, rs.getBigDecimal(1).intValue());
             }
-        }
-    }
-
-    @Test
-    void rollbackPorStockInsuficiente() {
-        assertThrows(IllegalStateException.class, () ->
-                service.registrarNuevoTramite(
-                        "Retiro de insumos",
-                        "Laboratorio",
-                        "",
-                        "Depósito",
-                        List.of(new TramiteService.LineaTramite(2, 6))
-                ));
-
-        try (Connection cn = DataSourceFactory.getConnection(); Statement st = cn.createStatement()) {
-            try (ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM tramite")) {
+            try (Statement st = cn.createStatement(); ResultSet rs = st.executeQuery("SELECT stock FROM insumo WHERE id = 2")) {
                 assertTrue(rs.next());
-                assertEquals(0, rs.getInt(1));
+                assertEquals(5, rs.getBigDecimal(1).intValue());
             }
-        } catch (Exception e) {
-            fail(e);
         }
     }
 
     @Test
-    void unificaLineasDuplicadas() throws Exception {
-        Long id = service.registrarNuevoTramite(
-                "Duplicados",
-                "Informes",
+    void pedidoEspecialGeneraSolicitudPendienteSinMovimientos() throws Exception {
+        TramiteService.RegistroTramite resultado = service.registrarNuevoTramite(
+                "Pedido especial",
+                "",
                 "",
                 "Mesa de entradas",
-                List.of(
-                        new TramiteService.LineaTramite(1, 2),
-                        new TramiteService.LineaTramite(1, 3)
-                )
+                List.of(TramiteService.LineaTramite.pedidoEspecial("Notebook", 1))
         );
+
+        assertEquals(1, resultado.getTramites().size());
+        Tramite especial = resultado.getTramites().get(0);
+        assertEquals("PENDIENTE", especial.getEstado());
+        assertTrue(especial.getNro().startsWith(resultado.getNumeroBase()));
 
         try (Connection cn = DataSourceFactory.getConnection()) {
             try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM tramite_detalle WHERE tramite_id=?")) {
-                ps.setLong(1, id);
+                ps.setLong(1, especial.getId());
                 try (ResultSet rs = ps.executeQuery()) {
                     assertTrue(rs.next());
-                    assertEquals(1, rs.getInt(1));
+                    assertEquals(0, rs.getInt(1));
                 }
             }
-
-            try (PreparedStatement ps = cn.prepareStatement("SELECT cantidad FROM movimiento WHERE tramite_id=?")) {
-                ps.setLong(1, id);
+            try (PreparedStatement ps = cn.prepareStatement("SELECT COUNT(*) FROM movimiento WHERE tramite_id=?")) {
+                ps.setLong(1, especial.getId());
                 try (ResultSet rs = ps.executeQuery()) {
                     assertTrue(rs.next());
-                    assertEquals(5, rs.getBigDecimal(1).intValue());
+                    assertEquals(0, rs.getInt(1));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- split solicitud registration into per-item tramites to support automatic completion when stock is available and pending records when it is not
- add special-order lines, updated destinations, and improved quantity editing in the registration dialog while renaming UI elements for the new flow
- refresh solicitudes tables, badges, and filters to use the new estado values and add coverage for the partial-registration scenarios

## Testing
- mvn -q test *(fails: unable to download junit-bom from Maven Central due to HTTP 403 in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a4186f07c8321a1c39153d1f1907f