### PR TITLE
Actualiza informes de inventario y movimientos

### DIFF
--- a/src/main/java/ar/edu/unse/siga/ui/pages/GestionesPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/GestionesPage.java
@@ -15,6 +15,8 @@ import ar.edu.unse.siga.ui.usuarios.UsuarioFormDialog;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import javax.swing.table.JTableHeader;
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -33,11 +35,15 @@ public class GestionesPage extends JPanel {
     private final UsuarioTableModel usuarioModel = new UsuarioTableModel();
     private final JTable tblUsuarios = new JTable(usuarioModel);
 
+    private static final Color BRAND = new Color(58, 96, 224);
+    private static final Color HEADER_TEXT = new Color(35, 55, 120);
+
     public GestionesPage(InventarioService inventarioService) {
         this.inventarioService = inventarioService;
 
         setOpaque(false);
-        setLayout(new BorderLayout(16, 16));
+        setLayout(new BorderLayout(20, 20));
+        setBorder(new EmptyBorder(12, 12, 12, 12));
 
         add(buildHeader(), BorderLayout.NORTH);
         add(buildContent(), BorderLayout.CENTER);
@@ -50,18 +56,39 @@ public class GestionesPage extends JPanel {
     private JComponent buildHeader() {
         JPanel header = new JPanel(new BorderLayout());
         header.setOpaque(false);
+
+        JPanel text = new JPanel();
+        text.setOpaque(false);
+        text.setLayout(new BoxLayout(text, BoxLayout.Y_AXIS));
+
         JLabel title = new JLabel("Gestiones administrativas");
-        title.setFont(title.getFont().deriveFont(Font.BOLD, 26f));
-        title.setForeground(new Color(28, 66, 148));
-        header.add(title, BorderLayout.WEST);
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 32f));
+        title.setForeground(HEADER_TEXT);
+
+        JLabel subtitle = new JLabel("Administra catálogos y usuarios de apoyo del sistema");
+        subtitle.setFont(subtitle.getFont().deriveFont(Font.PLAIN, 14f));
+        subtitle.setForeground(new Color(110, 126, 165));
+
+        text.add(title);
+        text.add(Box.createVerticalStrut(4));
+        text.add(subtitle);
+
+        header.add(text, BorderLayout.WEST);
         return header;
     }
 
     private JComponent buildContent() {
         CardPanel container = new CardPanel();
-        container.setLayout(new BorderLayout(12, 12));
+        container.setLayout(new BorderLayout());
+        container.setOpaque(false);
 
         JTabbedPane tabs = new JTabbedPane();
+        tabs.setFont(tabs.getFont().deriveFont(Font.BOLD, 14f));
+        tabs.setForeground(HEADER_TEXT);
+        tabs.setOpaque(false);
+        tabs.setBackground(Color.WHITE);
+        tabs.setBorder(new EmptyBorder(12, 12, 12, 12));
+
         tabs.addTab("Categorías", buildCategoriasTab());
         tabs.addTab("Ubicaciones", buildUbicacionesTab());
         tabs.addTab("Usuarios", buildUsuariosTab());
@@ -71,84 +98,97 @@ public class GestionesPage extends JPanel {
     }
 
     private JComponent buildCategoriasTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Catálogo de categorías", "Organiza los grupos disponibles para los insumos."), BorderLayout.NORTH);
+
+        styleTable(tblCategorias);
         tblCategorias.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblCategorias), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblCategorias);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNueva = new JButton("Nueva");
-        JButton btnRenombrar = new JButton("Renombrar");
-        JButton btnBaja = new JButton("Baja lógica");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNueva = primaryButton("Nueva");
+        JButton btnRenombrar = outlineButton("Renombrar");
+        JButton btnBaja = outlineButton("Baja lógica");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNueva, btnRenombrar, btnBaja, btnRestaurar);
 
         btnNueva.addActionListener(e -> onNuevaCategoria());
         btnRenombrar.addActionListener(e -> onRenombrarCategoria());
         btnBaja.addActionListener(e -> onBajaCategoria());
         btnRestaurar.addActionListener(e -> onRestaurarCategoria());
 
-        buttons.add(btnNueva);
-        buttons.add(btnRenombrar);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
     }
 
     private JComponent buildUbicacionesTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Ubicaciones", "Gestioná los espacios físicos de almacenamiento."), BorderLayout.NORTH);
+
+        styleTable(tblUbicaciones);
         tblUbicaciones.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblUbicaciones), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblUbicaciones);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNueva = new JButton("Nueva");
-        JButton btnRenombrar = new JButton("Renombrar");
-        JButton btnBaja = new JButton("Baja lógica");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNueva = primaryButton("Nueva");
+        JButton btnRenombrar = outlineButton("Renombrar");
+        JButton btnBaja = outlineButton("Baja lógica");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNueva, btnRenombrar, btnBaja, btnRestaurar);
 
         btnNueva.addActionListener(e -> onNuevaUbicacion());
         btnRenombrar.addActionListener(e -> onRenombrarUbicacion());
         btnBaja.addActionListener(e -> onBajaUbicacion());
         btnRestaurar.addActionListener(e -> onRestaurarUbicacion());
 
-        buttons.add(btnNueva);
-        buttons.add(btnRenombrar);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
     }
 
     private JComponent buildUsuariosTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Usuarios administrativos", "Gestioná los accesos del personal"), BorderLayout.NORTH);
+
+        styleTable(tblUsuarios);
         tblUsuarios.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblUsuarios), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblUsuarios);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNuevo = new JButton("Nuevo administrativo");
-        JButton btnBaja = new JButton("Dar de baja");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNuevo = primaryButton("Nuevo administrativo");
+        JButton btnBaja = outlineButton("Dar de baja");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNuevo, btnBaja, btnRestaurar);
 
         btnNuevo.addActionListener(e -> onNuevoAdministrativo());
         btnBaja.addActionListener(e -> onBajaUsuario());
         btnRestaurar.addActionListener(e -> onRestaurarUsuario());
 
-        buttons.add(btnNuevo);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
+    }
+
+    public void refreshData() {
+        loadCategorias();
+        loadUbicaciones();
+        loadUsuarios();
     }
 
     /* === Categorías === */
@@ -460,5 +500,90 @@ public class GestionesPage extends JPanel {
                 default -> "";
             };
         }
+    }
+
+    private JPanel sectionHeader(String title, String subtitle) {
+        JPanel header = new JPanel();
+        header.setOpaque(false);
+        header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
+
+        JLabel lblTitle = new JLabel(title);
+        lblTitle.setFont(lblTitle.getFont().deriveFont(Font.BOLD, 18f));
+        lblTitle.setForeground(HEADER_TEXT);
+
+        JLabel lblSubtitle = new JLabel(subtitle);
+        lblSubtitle.setFont(lblSubtitle.getFont().deriveFont(Font.PLAIN, 13f));
+        lblSubtitle.setForeground(new Color(110, 126, 165));
+
+        header.add(lblTitle);
+        header.add(Box.createVerticalStrut(4));
+        header.add(lblSubtitle);
+        return header;
+    }
+
+    private void styleTable(JTable table) {
+        table.setRowHeight(36);
+        table.setIntercellSpacing(new Dimension(0, 6));
+        table.setShowHorizontalLines(true);
+        table.setShowVerticalLines(false);
+        table.setGridColor(new Color(230, 235, 250));
+        table.setFillsViewportHeight(true);
+        table.setFont(table.getFont().deriveFont(Font.PLAIN, 13f));
+        table.setSelectionBackground(new Color(210, 222, 255));
+        table.setSelectionForeground(HEADER_TEXT);
+
+        JTableHeader header = table.getTableHeader();
+        header.setReorderingAllowed(false);
+        header.setFont(header.getFont().deriveFont(Font.BOLD, 13f));
+        header.setOpaque(true);
+        header.setBackground(new Color(242, 246, 255));
+        header.setForeground(HEADER_TEXT);
+        header.setBorder(new EmptyBorder(12, 12, 12, 12));
+    }
+
+    private JScrollPane tableScroll(JTable table) {
+        JScrollPane scroll = new JScrollPane(table);
+        scroll.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(225, 230, 246), 1, true),
+                new EmptyBorder(0, 0, 0, 0)
+        ));
+        scroll.getViewport().setBackground(Color.WHITE);
+        scroll.setOpaque(false);
+        return scroll;
+    }
+
+    private JPanel actionsRow(JButton... buttons) {
+        JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
+        row.setOpaque(false);
+        for (JButton b : buttons) {
+            row.add(b);
+        }
+        return row;
+    }
+
+    private JButton primaryButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setBackground(BRAND);
+        b.setForeground(Color.WHITE);
+        b.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(42, 80, 190), 1, true),
+                new EmptyBorder(10, 20, 10, 20)
+        ));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
+    }
+
+    private JButton outlineButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setBackground(Color.WHITE);
+        b.setForeground(BRAND.darker());
+        b.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(194, 206, 255), 1, true),
+                new EmptyBorder(10, 20, 10, 20)
+        ));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryMovementsPage.java
@@ -49,7 +49,7 @@ public class InventoryMovementsPage extends JPanel {
         var header = new JPanel(new BorderLayout());
         header.setOpaque(false);
 
-        var title = new JLabel("Registrar movimiento");
+        var title = new JLabel("Registrar entrada");
         title.setFont(title.getFont().deriveFont(Font.BOLD, 26f));
         title.setForeground(new Color(28, 66, 148));
         header.add(title, BorderLayout.WEST);
@@ -99,7 +99,7 @@ public class InventoryMovementsPage extends JPanel {
         JPanel north = new JPanel();
         north.setOpaque(false);
         north.setLayout(new BoxLayout(north, BoxLayout.Y_AXIS));
-        north.add(sectionTitle("Seleccionar insumo"));
+        north.add(sectionTitle("Búsqueda por nombre"));
         north.add(Box.createVerticalStrut(8));
 
         JPanel searchPanel = new JPanel(new BorderLayout(8, 0));
@@ -154,7 +154,7 @@ public class InventoryMovementsPage extends JPanel {
                     }
                 } else {
                     setActionsEnabled(false);
-                    taSeleccion.setText("Seleccioná un insumo");
+                    taSeleccion.setText("Seleccioná un elemento");
                     historialModel.clear();
                     if (resumenColorNormal != null) taSeleccion.setForeground(resumenColorNormal);
                 }
@@ -169,7 +169,7 @@ public class InventoryMovementsPage extends JPanel {
         CardPanel card = new CardPanel();
         card.setLayout(new BorderLayout(10, 10));
 
-        card.add(sectionTitle("Insumo seleccionado"), BorderLayout.NORTH);
+        card.add(sectionTitle("Elemento seleccionado"), BorderLayout.NORTH);
 
         taSeleccion.setOpaque(false);
         taSeleccion.setWrapStyleWord(true);
@@ -177,6 +177,7 @@ public class InventoryMovementsPage extends JPanel {
         taSeleccion.setEditable(false);
         taSeleccion.setFont(taSeleccion.getFont().deriveFont(Font.BOLD, 14f));
         taSeleccion.setBorder(new EmptyBorder(8, 8, 8, 8));
+        taSeleccion.setText("Seleccioná un elemento");
 
         var scroll = new JScrollPane(taSeleccion);
         scroll.setBorder(null);

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
@@ -118,6 +118,12 @@ public class InventoryPage extends JPanel {
         });
     }
 
+    public void refreshAll() {
+        registroPanel.refreshCombos();
+        modificarPanel.refreshData();
+        eliminarPanel.refreshData();
+    }
+
     private JToggleButton pillButton(String text) {
         JToggleButton b = new JToggleButton(text.toUpperCase());
         b.setFocusPainted(false);

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -90,6 +90,13 @@ public class TramiteEntradaPage extends JPanel {
         installEstadoListener();
     }
 
+    public void refreshAll() {
+        SwingUtilities.invokeLater(() -> {
+            loadTableData();
+            recargarTramitesRecientesSidebar();
+        });
+    }
+
     /* ====================  Estado editable (editor + listener)  ==================== */
 
     private void installEstadoEditor() {

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -1,9 +1,12 @@
 package ar.edu.unse.siga.ui.reportes;
 
+import ar.edu.unse.siga.common.CurrentSession;
+import ar.edu.unse.siga.common.RoleName;
 import ar.edu.unse.siga.domain.Categoria;
 import ar.edu.unse.siga.domain.Insumo;
 import ar.edu.unse.siga.domain.Tramite;
 import ar.edu.unse.siga.domain.Movimiento;
+import ar.edu.unse.siga.domain.Usuario;
 import ar.edu.unse.siga.service.InventarioService;
 import ar.edu.unse.siga.service.TramiteService;
 import ar.edu.unse.siga.ui.base.CardPanel;
@@ -119,9 +122,9 @@ public class InformesPanel extends JPanel {
     // --- SOLICITUDES (filtros) ---
     private final JTextField filterSearch = new JTextField(18);
     private final JComboBox<String> filterEstado
-            = new JComboBox<>(new String[]{"Todos", "Completado", "En proceso", "Pendiente"});
+            = new JComboBox<>(new String[]{"Todos", "Completado", "Pendiente", "Rechazado"});
     private final DefaultTableModel modelTra = new DefaultTableModel(
-            new Object[]{"ID Solicitud", "Solicitud", "Fecha de solicitud", "Fecha de atención", "Estado"}, 0
+            new Object[]{"ID Solicitud", "Solicitud", "Solicitante", "Fecha de solicitud", "Fecha de atención", "Estado"}, 0
     ) {
         @Override
         public boolean isCellEditable(int r, int c) {
@@ -390,7 +393,7 @@ public class InformesPanel extends JPanel {
         ButtonGroup tabs = new ButtonGroup();
         btnInventario = pill("INVENTARIO");
         btnTramites = pill("SOLICITUDES");
-        btnMovimientos = pill("MOVIMIENTOS");
+        btnMovimientos = pill("INGRESOS");
         btnInventario.setSelected(true);
         tabs.add(btnInventario);
         tabs.add(btnTramites);
@@ -1092,34 +1095,37 @@ public class InformesPanel extends JPanel {
 
         // Anchos
         TableColumnModel tcm = table.getColumnModel();
-        if (tcm.getColumnCount() >= 5) {
+        if (tcm.getColumnCount() >= 6) {
             tcm.getColumn(0).setPreferredWidth(130);
-            tcm.getColumn(1).setPreferredWidth(260);
-            tcm.getColumn(2).setPreferredWidth(190);
+            tcm.getColumn(1).setPreferredWidth(240);
+            tcm.getColumn(2).setPreferredWidth(200);
             tcm.getColumn(3).setPreferredWidth(190);
-            tcm.getColumn(4).setPreferredWidth(150);
+            tcm.getColumn(4).setPreferredWidth(190);
+            tcm.getColumn(5).setPreferredWidth(150);
         }
 
         JTableHeader header = table.getTableHeader();
         header.setPreferredSize(new Dimension(header.getPreferredSize().width, 46));
         header.setDefaultRenderer(new TableHeaderRenderer());
 
-        table.getColumnModel().getColumn(4).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.STATUS));
+        table.getColumnModel().getColumn(5).setCellRenderer(new BadgeRenderer(BadgeRenderer.Type.STATUS));
 
         // Zebra para el resto
         DefaultTableCellRenderer zebra = new DefaultTableCellRenderer() {
             @Override
             public Component getTableCellRendererComponent(JTable t, Object v, boolean s, boolean f, int r, int c) {
                 Component comp = super.getTableCellRendererComponent(t, v, s, f, r, c);
-                setHorizontalAlignment(c == 1 ? SwingConstants.LEFT : SwingConstants.CENTER);
+                setHorizontalAlignment((c == 1 || c == 2) ? SwingConstants.LEFT : SwingConstants.CENTER);
                 if (!s) {
                     comp.setBackground((r % 2 == 0) ? new Color(250, 252, 255) : Color.WHITE);
                 }
                 return comp;
             }
         };
-        for (int i = 0; i < 4 && i < table.getColumnCount(); i++) {
-            table.getColumnModel().getColumn(i).setCellRenderer(zebra);
+        for (int i = 0; i < table.getColumnCount(); i++) {
+            if (i != 5) {
+                table.getColumnModel().getColumn(i).setCellRenderer(zebra);
+            }
         }
 
         JScrollPane scroll = new JScrollPane(table,
@@ -1161,7 +1167,9 @@ public class InformesPanel extends JPanel {
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
             for (Tramite t : tramites) {
                 String solicitud = obtenerNombreInsumoSolicitado(t);
-                String solicitante = (t.getSolicitante() == null || t.getSolicitante().isBlank()) ? "" : t.getSolicitante();
+                String solicitanteRaw = t.getSolicitante();
+                String solicitante = (solicitanteRaw == null) ? "" : solicitanteRaw.trim();
+                String solicitanteDisplay = solicitante.isBlank() ? "-" : solicitante;
                 String descripcion = extraerDescripcionTramite(t);
 
                 if (!search.isEmpty()) {
@@ -1187,7 +1195,7 @@ public class InformesPanel extends JPanel {
                     }
                 }
 
-                modelTra.addRow(new Object[]{t.getNro(), solicitud, fechaSolicitud, fechaAtencion, estado});
+                modelTra.addRow(new Object[]{t.getNro(), solicitud, solicitanteDisplay, fechaSolicitud, fechaAtencion, estado});
             }
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -1322,6 +1330,9 @@ public class InformesPanel extends JPanel {
         if (e.contains("comp")) {
             return "Completado";
         }
+        if (e.contains("rech")) {
+            return "Rechazado";
+        }
         if (e.contains("proc")) {
             return "En proceso";
         }
@@ -1422,7 +1433,7 @@ public class InformesPanel extends JPanel {
             @Override
             public Component getTableCellRendererComponent(JTable t, Object v, boolean s, boolean f, int r, int c) {
                 Component comp = super.getTableCellRendererComponent(t, v, s, f, r, c);
-                setHorizontalAlignment(c == 4 ? SwingConstants.LEFT : CENTER);
+                setHorizontalAlignment((c == 4 || c == 6) ? SwingConstants.LEFT : CENTER);
                 if (!s) {
                     comp.setBackground((r % 2 == 0) ? new Color(250, 252, 255) : Color.WHITE);
                 }
@@ -1717,25 +1728,84 @@ public class InformesPanel extends JPanel {
 
         try {
             writePdfSafely(out, doc -> {
-                addPdfHeader(doc, "Informe de Inventario");
+                String estadoSel = (String) cbEstadoInventario.getSelectedItem();
+                String tipoSel = (String) cbTipoInventario.getSelectedItem();
+                addPdfHeader(doc, tituloInventarioPdf(estadoSel, tipoSel));
 
-                java.util.List<String[]> rows = new java.util.ArrayList<>();
-                for (int r = 0; r < modelInv.getRowCount(); r++) {
-                    rows.add(new String[]{
-                        displayString(modelInv.getValueAt(r, 0)),
-                        displayString(modelInv.getValueAt(r, 1)),
-                        displayString(modelInv.getValueAt(r, 4)),
-                        displayString(modelInv.getValueAt(r, 5))
-                    });
+                boolean general = isTodos(estadoSel) && isTodos(tipoSel);
+
+                if (general) {
+                    java.util.List<String[]> activos = new java.util.ArrayList<>();
+                    java.util.List<String[]> inactivos = new java.util.ArrayList<>();
+
+                    for (int r = 0; r < modelInv.getRowCount(); r++) {
+                        String codigo = displayString(modelInv.getValueAt(r, 0));
+                        String descripcion = displayString(modelInv.getValueAt(r, 1));
+                        String tipo = displayString(modelInv.getValueAt(r, 2));
+                        String stockActual = displayString(modelInv.getValueAt(r, 4));
+                        String stockMinimo = displayString(modelInv.getValueAt(r, 5));
+                        String estado = rawString(modelInv.getValueAt(r, 3));
+
+                        String[] data = new String[]{codigo, descripcion, tipo, stockActual, stockMinimo};
+                        if ("Inactivo".equalsIgnoreCase(estado)) {
+                            inactivos.add(data);
+                        } else {
+                            activos.add(data);
+                        }
+                    }
+
+                    if (activos.isEmpty() && inactivos.isEmpty()) {
+                        Paragraph sinDatos = new Paragraph("No se registran insumos para los filtros seleccionados.", FONT_TABLE_CELL);
+                        sinDatos.setAlignment(Element.ALIGN_LEFT);
+                        doc.add(sinDatos);
+                    } else {
+                        String[] headers = new String[]{"Código", "Descripción", "Tipo", "Stock actual", "Stock mínimo"};
+                        float[] widths = new float[]{2.2f, 4f, 2f, 2.2f, 2.2f};
+                        int[] aligns = new int[]{Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_CENTER, Element.ALIGN_CENTER, Element.ALIGN_CENTER};
+
+                        Paragraph activosTitulo = new Paragraph("Activos", FONT_SECTION);
+                        activosTitulo.setSpacingBefore(6f);
+                        activosTitulo.setSpacingAfter(4f);
+                        doc.add(activosTitulo);
+                        doc.add(buildStyledTable(headers, activos, widths, aligns));
+                        if (activos.isEmpty()) {
+                            Paragraph sinActivos = new Paragraph("Sin registros de activos.", FONT_TABLE_CELL);
+                            sinActivos.setAlignment(Element.ALIGN_LEFT);
+                            doc.add(sinActivos);
+                        }
+
+                        Paragraph inactivosTitulo = new Paragraph("Inactivos", FONT_SECTION);
+                        inactivosTitulo.setSpacingBefore(12f);
+                        inactivosTitulo.setSpacingAfter(4f);
+                        doc.add(inactivosTitulo);
+                        doc.add(buildStyledTable(headers, inactivos, widths, aligns));
+                        if (inactivos.isEmpty()) {
+                            Paragraph sinInactivos = new Paragraph("Sin registros de inactivos.", FONT_TABLE_CELL);
+                            sinInactivos.setAlignment(Element.ALIGN_LEFT);
+                            doc.add(sinInactivos);
+                        }
+                    }
+                } else {
+                    java.util.List<String[]> rows = new java.util.ArrayList<>();
+                    for (int r = 0; r < modelInv.getRowCount(); r++) {
+                        rows.add(new String[]{
+                                displayString(modelInv.getValueAt(r, 0)),
+                                displayString(modelInv.getValueAt(r, 1)),
+                                displayString(modelInv.getValueAt(r, 2)),
+                                displayString(modelInv.getValueAt(r, 3)),
+                                displayString(modelInv.getValueAt(r, 4)),
+                                displayString(modelInv.getValueAt(r, 5))
+                        });
+                    }
+
+                    PdfPTable table = buildStyledTable(
+                            new String[]{"Código", "Descripción", "Tipo", "Estado", "Stock actual", "Stock mínimo"},
+                            rows,
+                            new float[]{2.2f, 4f, 2f, 1.8f, 2.2f, 2.2f},
+                            new int[]{Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_CENTER, Element.ALIGN_CENTER, Element.ALIGN_CENTER, Element.ALIGN_CENTER}
+                    );
+                    doc.add(table);
                 }
-
-                PdfPTable table = buildStyledTable(
-                        new String[]{"Código", "Descripción", "Stock actual", "Stock mínimo"},
-                        rows,
-                        new float[]{2.2f, 4f, 2.2f, 2.2f},
-                        new int[]{Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_CENTER, Element.ALIGN_CENTER}
-                );
-                doc.add(table);
 
                 java.util.LinkedHashMap<String, String> resumen = new java.util.LinkedHashMap<>();
                 resumen.put("Total de ítems registrados", String.valueOf(modelInv.getRowCount()));
@@ -1751,6 +1821,25 @@ public class InformesPanel extends JPanel {
             JOptionPane.showMessageDialog(this, "No se pudo generar el PDF:\n" + ex.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    private String tituloInventarioPdf(String estadoSel, String tipoSel) {
+        if (isTodos(tipoSel) && isTodos(estadoSel)) {
+            return "Informe general de inventario";
+        }
+        if (!isTodos(tipoSel)) {
+            if ("Bienes".equalsIgnoreCase(tipoSel)) {
+                return "Informe de inventario de bienes";
+            }
+            if ("Insumos".equalsIgnoreCase(tipoSel)) {
+                return "Informe de inventario de insumos";
+            }
+        }
+        return "Informe de Inventario";
+    }
+
+    private boolean isTodos(String value) {
+        return value == null || value.trim().equalsIgnoreCase("Todos");
     }
 
     private interface PdfBody {
@@ -1807,17 +1896,18 @@ public class InformesPanel extends JPanel {
                 for (int r = 0; r < modelTra.getRowCount(); r++) {
                     String nro = displayString(modelTra.getValueAt(r, 0)); // Nro Trámite
                     String solicitud = displayString(modelTra.getValueAt(r, 1));
-                    String fechaSolicitud = displayString(modelTra.getValueAt(r, 2));
-                    String fechaAtencion = displayString(modelTra.getValueAt(r, 3));
-                    String estado = displayString(modelTra.getValueAt(r, 4));
-                    rows.add(new String[]{nro, solicitud, fechaSolicitud, fechaAtencion, estado});
+                    String solicitante = displayString(modelTra.getValueAt(r, 2));
+                    String fechaSolicitud = displayString(modelTra.getValueAt(r, 3));
+                    String fechaAtencion = displayString(modelTra.getValueAt(r, 4));
+                    String estado = displayString(modelTra.getValueAt(r, 5));
+                    rows.add(new String[]{nro, solicitud, solicitante, fechaSolicitud, fechaAtencion, estado});
                 }
 
                 PdfPTable table = buildStyledTable(
-                        new String[]{"Nro Trámite", "Solicitud", "Fecha solicitud", "Fecha atención", "Estado"},
+                        new String[]{"Nro Trámite", "Solicitud", "Solicitante", "Fecha solicitud", "Fecha atención", "Estado"},
                         rows,
-                        new float[]{2f, 3.5f, 2.4f, 2.4f, 2f},
-                        new int[]{Element.ALIGN_CENTER, Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_CENTER, Element.ALIGN_CENTER}
+                        new float[]{2f, 3.4f, 2.6f, 2.4f, 2.4f, 2f},
+                        new int[]{Element.ALIGN_CENTER, Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_LEFT, Element.ALIGN_CENTER, Element.ALIGN_CENTER}
                 );
                 doc.add(table);
 
@@ -1828,7 +1918,7 @@ public class InformesPanel extends JPanel {
                 resumen.put("Completadas", String.valueOf(estados.getOrDefault("Completadas", 0)));
                 resumen.put("Rechazadas", String.valueOf(estados.getOrDefault("Rechazadas", 0)));
                 resumen.put("Alta", String.valueOf(estados.getOrDefault("Alta", 0)));
-                addSummarySection(doc, "Estadísticas", resumen);
+                addSummarySection(doc, "Totales", resumen);
 
                 addPdfFooter(doc);
             });
@@ -1848,7 +1938,14 @@ public class InformesPanel extends JPanel {
 
         try {
             writePdfSafely(out, doc -> {
-                addPdfHeader(doc, "Informe de Movimientos de Inventario");
+                String tipoSel = (cbTipoMov != null && cbTipoMov.getSelectedItem() != null)
+                        ? cbTipoMov.getSelectedItem().toString().trim()
+                        : "Todos";
+                String periodoSel = (cbPeriodoMov != null && cbPeriodoMov.getSelectedItem() != null)
+                        ? cbPeriodoMov.getSelectedItem().toString().trim()
+                        : "Todos";
+
+                addPdfHeader(doc, tituloMovimientosPdf(tipoSel, periodoSel));
 
                 java.util.List<String[]> entradas = new java.util.ArrayList<>();
                 java.util.List<String[]> salidas = new java.util.ArrayList<>();
@@ -1856,55 +1953,47 @@ public class InformesPanel extends JPanel {
                 java.math.BigDecimal totalSalidas = java.math.BigDecimal.ZERO;
 
                 for (int r = 0; r < modelMov.getRowCount(); r++) {
-                    String tipo = rawString(modelMov.getValueAt(r, 1)).toUpperCase(java.util.Locale.ROOT);
+                    String tipo = rawString(modelMov.getValueAt(r, 1));
                     java.math.BigDecimal cantidad = parseCantidad(modelMov.getValueAt(r, 2));
                     String fecha = displayString(modelMov.getValueAt(r, 0));
                     String codigo = rawString(modelMov.getValueAt(r, 3));
                     String desc = rawString(modelMov.getValueAt(r, 4));
-                    String insumo = (codigo.isBlank() ? desc : (codigo + " - " + desc));
-                    if (insumo == null || insumo.isBlank()) {
-                        insumo = "-";
+                    String elemento = (codigo.isBlank() ? desc : (codigo + " - " + desc));
+                    if (elemento == null || elemento.isBlank()) {
+                        elemento = "-";
                     }
-                    String origenDestino = rawString(modelMov.getValueAt(r, 5));
-                    if (origenDestino.isBlank()) {
-                        origenDestino = "-";
-                    }
-
-                    String[] data = new String[]{fecha, insumo, formatDecimal(cantidad), origenDestino, (tipo.isBlank() ? "-" : tipo)};
+                    String origenDestino = displayString(modelMov.getValueAt(r, 5));
+                    String solicitante = displayString(modelMov.getValueAt(r, 6));
 
                     if ("ENTRADA".equalsIgnoreCase(tipo)) {
-                        entradas.add(data);
+                        entradas.add(new String[]{fecha, elemento, formatDecimal(cantidad), origenDestino});
                         totalEntradas = totalEntradas.add(cantidad);
                     } else if ("SALIDA".equalsIgnoreCase(tipo)) {
-                        salidas.add(data);
+                        salidas.add(new String[]{fecha, elemento, formatDecimal(cantidad), origenDestino, solicitante});
                         totalSalidas = totalSalidas.add(cantidad);
                     }
                 }
 
-                String[] headers = new String[]{"Fecha", "Insumo", "Cantidad", "Origen/Destino", "Tipo"};
-                float[] widths = new float[]{2f, 4f, 1.8f, 3f, 1.6f};
-                int[] aligns = new int[]{Element.ALIGN_CENTER, Element.ALIGN_LEFT, Element.ALIGN_RIGHT, Element.ALIGN_LEFT, Element.ALIGN_CENTER};
+                boolean soloEntradas = "ENTRADA".equalsIgnoreCase(tipoSel);
+                boolean soloSalidas = "SALIDA".equalsIgnoreCase(tipoSel);
 
-                if (!entradas.isEmpty()) {
-                    Paragraph sec = new Paragraph("Movimientos de Entrada", FONT_SECTION);
-                    sec.setSpacingBefore(8f);
-                    sec.setSpacingAfter(4f);
-                    doc.add(sec);
-                    doc.add(buildStyledTable(headers, entradas, widths, aligns));
-                }
-
-                if (!salidas.isEmpty()) {
-                    Paragraph sec = new Paragraph("Movimientos de Salida", FONT_SECTION);
-                    sec.setSpacingBefore(12f);
-                    sec.setSpacingAfter(4f);
-                    doc.add(sec);
-                    doc.add(buildStyledTable(headers, salidas, widths, aligns));
-                }
-
-                if (entradas.isEmpty() && salidas.isEmpty()) {
-                    Paragraph sinDatos = new Paragraph("No se registran movimientos para el período seleccionado.", FONT_TABLE_CELL);
-                    sinDatos.setAlignment(Element.ALIGN_LEFT);
-                    doc.add(sinDatos);
+                if (soloEntradas) {
+                    agregarTablaEntradas(doc, entradas, true);
+                    if (entradas.isEmpty()) {
+                        agregarMensajeSinDatos(doc);
+                    }
+                } else if (soloSalidas) {
+                    agregarTablaSalidas(doc, salidas, true);
+                    if (salidas.isEmpty()) {
+                        agregarMensajeSinDatos(doc);
+                    }
+                } else {
+                    boolean hayDatos = !entradas.isEmpty() || !salidas.isEmpty();
+                    agregarTablaEntradas(doc, entradas, false);
+                    agregarTablaSalidas(doc, salidas, false);
+                    if (!hayDatos) {
+                        agregarMensajeSinDatos(doc);
+                    }
                 }
 
                 java.util.LinkedHashMap<String, String> resumen = new java.util.LinkedHashMap<>();
@@ -1920,6 +2009,55 @@ public class InformesPanel extends JPanel {
             JOptionPane.showMessageDialog(this, "No se pudo generar el PDF:\n" + ex.getMessage(),
                     "Error", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    private String tituloMovimientosPdf(String tipoSel, String periodoSel) {
+        String titulo;
+        if ("ENTRADA".equalsIgnoreCase(tipoSel)) {
+            titulo = "Informe de entradas registradas";
+        } else if ("SALIDA".equalsIgnoreCase(tipoSel)) {
+            titulo = "Informe de salidas registradas";
+        } else {
+            titulo = "Informe general de movimientos del inventario";
+        }
+
+        if ("ÚLTIMOS 7 DÍAS".equalsIgnoreCase(periodoSel) || "ULTIMOS 7 DIAS".equalsIgnoreCase(periodoSel)) {
+            titulo = "Informe de los movimientos registrados en los últimos 7 días";
+        } else if ("HOY".equalsIgnoreCase(periodoSel)) {
+            titulo = "Informe de movimientos registrados a día de la fecha";
+        }
+        return titulo;
+    }
+
+    private void agregarTablaEntradas(Document doc, java.util.List<String[]> entradas, boolean solo) throws DocumentException {
+        Paragraph titulo = new Paragraph("Entradas registradas", FONT_SECTION);
+        titulo.setSpacingBefore(solo ? 8f : 8f);
+        titulo.setSpacingAfter(4f);
+        doc.add(titulo);
+
+        String[] headers = new String[]{"Fecha", "Elemento", "Cantidad", "Origen/Destino"};
+        float[] widths = new float[]{2f, 4.2f, 1.8f, 3.2f};
+        int[] aligns = new int[]{Element.ALIGN_CENTER, Element.ALIGN_LEFT, Element.ALIGN_RIGHT, Element.ALIGN_LEFT};
+        doc.add(buildStyledTable(headers, entradas, widths, aligns));
+    }
+
+    private void agregarTablaSalidas(Document doc, java.util.List<String[]> salidas, boolean solo) throws DocumentException {
+        Paragraph titulo = new Paragraph("Salidas registradas", FONT_SECTION);
+        titulo.setSpacingBefore(solo ? 8f : 12f);
+        titulo.setSpacingAfter(4f);
+        doc.add(titulo);
+
+        String[] headers = new String[]{"Fecha", "Elemento", "Cantidad", "Destino", "Solicitante"};
+        float[] widths = new float[]{2f, 3.8f, 1.8f, 3f, 2.4f};
+        int[] aligns = new int[]{Element.ALIGN_CENTER, Element.ALIGN_LEFT, Element.ALIGN_RIGHT, Element.ALIGN_LEFT, Element.ALIGN_LEFT};
+        doc.add(buildStyledTable(headers, salidas, widths, aligns));
+    }
+
+    private void agregarMensajeSinDatos(Document doc) throws DocumentException {
+        Paragraph sinDatos = new Paragraph("No se registran movimientos para los filtros seleccionados.", FONT_TABLE_CELL);
+        sinDatos.setAlignment(Element.ALIGN_LEFT);
+        sinDatos.setSpacingBefore(8f);
+        doc.add(sinDatos);
     }
 
     private File choosePdfDestination(String defaultName) {
@@ -1973,6 +2111,11 @@ public class InformesPanel extends JPanel {
         tituloParrafo.setSpacingAfter(2f);
         infoCell.addElement(tituloParrafo);
 
+        Paragraph generado = new Paragraph(buildGeneradoPor(), FONT_HEADER_DATE);
+        generado.setAlignment(Element.ALIGN_LEFT);
+        generado.setSpacingAfter(2f);
+        infoCell.addElement(generado);
+
         header.addCell(infoCell);
         doc.add(header);
 
@@ -1980,6 +2123,31 @@ public class InformesPanel extends JPanel {
         fecha.setAlignment(Element.ALIGN_RIGHT);
         doc.add(fecha);
         doc.add(Chunk.NEWLINE);
+    }
+
+    private String buildGeneradoPor() {
+        Usuario usuario = CurrentSession.getUser();
+        if (usuario == null) {
+            return "Generado por: -";
+        }
+
+        if (RoleName.isAdmin(usuario)) {
+            return "Generado por: Administrador";
+        }
+
+        String nombre = usuario.getUsuario();
+        if (nombre == null || nombre.isBlank()) {
+            nombre = usuario.getUsername();
+        }
+        if (nombre == null || nombre.isBlank()) {
+            nombre = "-";
+        }
+
+        if (RoleName.hasRole(usuario, RoleName.ADMINISTRATIVO)) {
+            return "Generado por: Administrativo - " + nombre;
+        }
+
+        return "Generado por: " + nombre;
     }
 
     private void addPdfFooter(Document doc) throws DocumentException {
@@ -2120,7 +2288,7 @@ public class InformesPanel extends JPanel {
         counts.put("Alta", 0);
 
         for (int r = 0; r < modelTra.getRowCount(); r++) {
-            String estado = estadoFriendly(rawString(modelTra.getValueAt(r, 4)));
+            String estado = estadoFriendly(rawString(modelTra.getValueAt(r, 5)));
             switch (estado) {
                 case "Pendiente" -> counts.computeIfPresent("Pendientes", (k, v) -> v + 1);
                 case "Completado" -> counts.computeIfPresent("Completadas", (k, v) -> v + 1);

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -675,6 +675,14 @@ public class InformesPanel extends JPanel {
         }
     }
 
+    public void refreshData() {
+        reloadMetrics();
+        runQueryInventario();
+        loadTableDataTramites();
+        loadTableDataMovimientos();
+        loadRetirosRecientes();
+    }
+
     private void runQueryInventario() {
         modelInv.setRowCount(0);
         lblTotalStockMinimo.setText("0");
@@ -750,7 +758,7 @@ public class InformesPanel extends JPanel {
     }
 
     private boolean matchesEstado(Insumo insumo, String filtro) {
-        if (filtro == null || filtro.equalsIgnoreCase("Todos")) {
+        if (isTodos(filtro) || (filtro != null && filtro.trim().isEmpty())) {
             return true;
         }
         String estado = normalizeEstado(insumo.getEstado());
@@ -764,14 +772,15 @@ public class InformesPanel extends JPanel {
     }
 
     private boolean matchesTipo(Insumo insumo, String filtro) {
-        if (filtro == null || filtro.equalsIgnoreCase("Todos")) {
+        if (isTodos(filtro) || (filtro != null && filtro.trim().isEmpty())) {
             return true;
         }
+        String criterio = filtro.trim().toUpperCase(Locale.ROOT);
         String tipo = normalizeTipo(insumo.getTipo());
-        if (filtro.equalsIgnoreCase("Insumos")) {
+        if (criterio.startsWith("INS")) {
             return "INSUMO".equals(tipo);
         }
-        if (filtro.equalsIgnoreCase("Bienes")) {
+        if (criterio.startsWith("BIE")) {
             return "BIEN".equals(tipo);
         }
         return true;
@@ -847,8 +856,8 @@ public class InformesPanel extends JPanel {
                 .map(r -> normalizeTipo(r.insumo.getTipo()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        boolean dividirEstado = estadoSel != null && estadoSel.equalsIgnoreCase("Todos") && estados.size() > 1;
-        boolean dividirTipo = tipoSel != null && tipoSel.equalsIgnoreCase("Todos") && tipos.size() > 1;
+        boolean dividirEstado = isTodos(estadoSel) && estados.size() > 1;
+        boolean dividirTipo = isTodos(tipoSel) && tipos.size() > 1;
 
         if (dividirEstado && dividirTipo) {
             for (String estado : estados) {

--- a/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
@@ -29,6 +29,7 @@ public class ShellFrame extends JFrame {
     private final JPanel cards = new JPanel(cardLayout);
     private final JLabel lblTitle = new JLabel("Inicio");
     private final JLabel lblUser = new JLabel();
+    private final JButton btnRefresh = createRefreshButton();
 
     // services
     private final InventarioService inventarioService;
@@ -45,6 +46,7 @@ public class ShellFrame extends JFrame {
     // mapa de clave de tarjeta -> botón del sidebar
     private final Map<String, NavButton> navByKey = new HashMap<>();
     private final ButtonGroup navGroup = new ButtonGroup();
+    private String currentKey = "home";
 
     public ShellFrame(InventarioService inv, TramiteService tra, AuthService auth) {
         super("SIGA-FCEyT");
@@ -167,7 +169,13 @@ public class ShellFrame extends JFrame {
         lblUser.setText((u != null ? u.getUsername() : "-")
                 + "  |  " + java.time.LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
         lblUser.setForeground(new Color(90, 110, 150));
-        header.add(lblUser, BorderLayout.EAST);
+        lblUser.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+
+        JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
+        right.setOpaque(false);
+        right.add(btnRefresh);
+        right.add(lblUser);
+        header.add(right, BorderLayout.EAST);
         return header;
     }
 
@@ -274,6 +282,7 @@ public class ShellFrame extends JFrame {
     private void showCard(String key, String title) {
         cardLayout.show(cards, key);
         lblTitle.setText(title);
+        currentKey = key;
 
         // marcar seleccionado el botón correspondiente
         for (Map.Entry<String, NavButton> e : navByKey.entrySet()) {
@@ -294,5 +303,54 @@ public class ShellFrame extends JFrame {
 
     private void addPage(String key, Component c) {
         cards.add(c, key);
+    }
+
+    private JButton createRefreshButton() {
+        JButton btn = new JButton("Refrescar");
+        btn.setFocusPainted(false);
+        btn.setBackground(new Color(58, 96, 224));
+        btn.setForeground(Color.WHITE);
+        btn.setBorder(BorderFactory.createEmptyBorder(8, 18, 8, 18));
+        btn.putClientProperty("JButton.buttonType", "roundRect");
+        btn.addActionListener(e -> refreshCurrentPage());
+        return btn;
+    }
+
+    private void refreshCurrentPage() {
+        switch (currentKey) {
+            case "home" -> {
+                if (homePage != null) {
+                    homePage.refreshMetrics();
+                    homePage.recargarTramitesRecientes();
+                }
+            }
+            case "inventario" -> {
+                if (inventoryPage != null) {
+                    inventoryPage.refreshAll();
+                }
+            }
+            case "movimientos" -> {
+                if (movimientosPage != null) {
+                    movimientosPage.refreshInsumos();
+                }
+            }
+            case "tramites" -> {
+                if (tramitesPage != null) {
+                    tramitesPage.refreshAll();
+                }
+            }
+            case "reportes" -> {
+                if (informesPanel != null) {
+                    informesPanel.refreshData();
+                }
+            }
+            case "gestiones" -> {
+                if (gestionesPage != null) {
+                    gestionesPage.refreshData();
+                }
+            }
+            default -> {
+            }
+        }
     }
 }


### PR DESCRIPTION
## Resumen
- Renombra la sección de movimientos a ingresos y actualiza los textos del registro de entradas.
- Ajusta los informes de solicitudes con la nueva columna de solicitante, filtros revisados y detalle de quién genera cada PDF.
- Reestructura la exportación de inventario y movimientos para reflejar los títulos, tablas y columnas solicitadas.

## Pruebas
- `mvn -q -DskipTests package` *(falla: dependencia org.junit:junit-bom con respuesta 403 de Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691244c55c248321bf374697d7c1a9ab)