### PR TITLE
Fix inventory report filter and add global refresh control

### DIFF
--- a/src/main/java/ar/edu/unse/siga/ui/pages/GestionesPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/GestionesPage.java
@@ -15,6 +15,8 @@ import ar.edu.unse.siga.ui.usuarios.UsuarioFormDialog;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import javax.swing.table.JTableHeader;
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -33,11 +35,15 @@ public class GestionesPage extends JPanel {
     private final UsuarioTableModel usuarioModel = new UsuarioTableModel();
     private final JTable tblUsuarios = new JTable(usuarioModel);
 
+    private static final Color BRAND = new Color(58, 96, 224);
+    private static final Color HEADER_TEXT = new Color(35, 55, 120);
+
     public GestionesPage(InventarioService inventarioService) {
         this.inventarioService = inventarioService;
 
         setOpaque(false);
-        setLayout(new BorderLayout(16, 16));
+        setLayout(new BorderLayout(20, 20));
+        setBorder(new EmptyBorder(12, 12, 12, 12));
 
         add(buildHeader(), BorderLayout.NORTH);
         add(buildContent(), BorderLayout.CENTER);
@@ -50,18 +56,39 @@ public class GestionesPage extends JPanel {
     private JComponent buildHeader() {
         JPanel header = new JPanel(new BorderLayout());
         header.setOpaque(false);
+
+        JPanel text = new JPanel();
+        text.setOpaque(false);
+        text.setLayout(new BoxLayout(text, BoxLayout.Y_AXIS));
+
         JLabel title = new JLabel("Gestiones administrativas");
-        title.setFont(title.getFont().deriveFont(Font.BOLD, 26f));
-        title.setForeground(new Color(28, 66, 148));
-        header.add(title, BorderLayout.WEST);
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 32f));
+        title.setForeground(HEADER_TEXT);
+
+        JLabel subtitle = new JLabel("Administra catálogos y usuarios de apoyo del sistema");
+        subtitle.setFont(subtitle.getFont().deriveFont(Font.PLAIN, 14f));
+        subtitle.setForeground(new Color(110, 126, 165));
+
+        text.add(title);
+        text.add(Box.createVerticalStrut(4));
+        text.add(subtitle);
+
+        header.add(text, BorderLayout.WEST);
         return header;
     }
 
     private JComponent buildContent() {
         CardPanel container = new CardPanel();
-        container.setLayout(new BorderLayout(12, 12));
+        container.setLayout(new BorderLayout());
+        container.setOpaque(false);
 
         JTabbedPane tabs = new JTabbedPane();
+        tabs.setFont(tabs.getFont().deriveFont(Font.BOLD, 14f));
+        tabs.setForeground(HEADER_TEXT);
+        tabs.setOpaque(false);
+        tabs.setBackground(Color.WHITE);
+        tabs.setBorder(new EmptyBorder(12, 12, 12, 12));
+
         tabs.addTab("Categorías", buildCategoriasTab());
         tabs.addTab("Ubicaciones", buildUbicacionesTab());
         tabs.addTab("Usuarios", buildUsuariosTab());
@@ -71,84 +98,97 @@ public class GestionesPage extends JPanel {
     }
 
     private JComponent buildCategoriasTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Catálogo de categorías", "Organiza los grupos disponibles para los insumos."), BorderLayout.NORTH);
+
+        styleTable(tblCategorias);
         tblCategorias.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblCategorias), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblCategorias);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNueva = new JButton("Nueva");
-        JButton btnRenombrar = new JButton("Renombrar");
-        JButton btnBaja = new JButton("Baja lógica");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNueva = primaryButton("Nueva");
+        JButton btnRenombrar = outlineButton("Renombrar");
+        JButton btnBaja = outlineButton("Baja lógica");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNueva, btnRenombrar, btnBaja, btnRestaurar);
 
         btnNueva.addActionListener(e -> onNuevaCategoria());
         btnRenombrar.addActionListener(e -> onRenombrarCategoria());
         btnBaja.addActionListener(e -> onBajaCategoria());
         btnRestaurar.addActionListener(e -> onRestaurarCategoria());
 
-        buttons.add(btnNueva);
-        buttons.add(btnRenombrar);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
     }
 
     private JComponent buildUbicacionesTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Ubicaciones", "Gestioná los espacios físicos de almacenamiento."), BorderLayout.NORTH);
+
+        styleTable(tblUbicaciones);
         tblUbicaciones.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblUbicaciones), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblUbicaciones);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNueva = new JButton("Nueva");
-        JButton btnRenombrar = new JButton("Renombrar");
-        JButton btnBaja = new JButton("Baja lógica");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNueva = primaryButton("Nueva");
+        JButton btnRenombrar = outlineButton("Renombrar");
+        JButton btnBaja = outlineButton("Baja lógica");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNueva, btnRenombrar, btnBaja, btnRestaurar);
 
         btnNueva.addActionListener(e -> onNuevaUbicacion());
         btnRenombrar.addActionListener(e -> onRenombrarUbicacion());
         btnBaja.addActionListener(e -> onBajaUbicacion());
         btnRestaurar.addActionListener(e -> onRestaurarUbicacion());
 
-        buttons.add(btnNueva);
-        buttons.add(btnRenombrar);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
     }
 
     private JComponent buildUsuariosTab() {
-        JPanel panel = new JPanel(new BorderLayout(8, 8));
+        CardPanel panel = new CardPanel();
+        panel.setLayout(new BorderLayout(18, 18));
         panel.setOpaque(false);
-        panel.setBorder(new EmptyBorder(12, 12, 12, 12));
+        panel.setBorder(new EmptyBorder(18, 18, 18, 18));
 
+        panel.add(sectionHeader("Usuarios administrativos", "Gestioná los accesos del personal"), BorderLayout.NORTH);
+
+        styleTable(tblUsuarios);
         tblUsuarios.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        panel.add(new JScrollPane(tblUsuarios), BorderLayout.CENTER);
+        JScrollPane scroll = tableScroll(tblUsuarios);
+        panel.add(scroll, BorderLayout.CENTER);
 
-        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        JButton btnNuevo = new JButton("Nuevo administrativo");
-        JButton btnBaja = new JButton("Dar de baja");
-        JButton btnRestaurar = new JButton("Restaurar");
+        JButton btnNuevo = primaryButton("Nuevo administrativo");
+        JButton btnBaja = outlineButton("Dar de baja");
+        JButton btnRestaurar = outlineButton("Restaurar");
+
+        JPanel buttons = actionsRow(btnNuevo, btnBaja, btnRestaurar);
 
         btnNuevo.addActionListener(e -> onNuevoAdministrativo());
         btnBaja.addActionListener(e -> onBajaUsuario());
         btnRestaurar.addActionListener(e -> onRestaurarUsuario());
 
-        buttons.add(btnNuevo);
-        buttons.add(btnBaja);
-        buttons.add(btnRestaurar);
-        panel.add(buttons, BorderLayout.NORTH);
+        panel.add(buttons, BorderLayout.SOUTH);
 
         return panel;
+    }
+
+    public void refreshData() {
+        loadCategorias();
+        loadUbicaciones();
+        loadUsuarios();
     }
 
     /* === Categorías === */
@@ -460,5 +500,90 @@ public class GestionesPage extends JPanel {
                 default -> "";
             };
         }
+    }
+
+    private JPanel sectionHeader(String title, String subtitle) {
+        JPanel header = new JPanel();
+        header.setOpaque(false);
+        header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
+
+        JLabel lblTitle = new JLabel(title);
+        lblTitle.setFont(lblTitle.getFont().deriveFont(Font.BOLD, 18f));
+        lblTitle.setForeground(HEADER_TEXT);
+
+        JLabel lblSubtitle = new JLabel(subtitle);
+        lblSubtitle.setFont(lblSubtitle.getFont().deriveFont(Font.PLAIN, 13f));
+        lblSubtitle.setForeground(new Color(110, 126, 165));
+
+        header.add(lblTitle);
+        header.add(Box.createVerticalStrut(4));
+        header.add(lblSubtitle);
+        return header;
+    }
+
+    private void styleTable(JTable table) {
+        table.setRowHeight(36);
+        table.setIntercellSpacing(new Dimension(0, 6));
+        table.setShowHorizontalLines(true);
+        table.setShowVerticalLines(false);
+        table.setGridColor(new Color(230, 235, 250));
+        table.setFillsViewportHeight(true);
+        table.setFont(table.getFont().deriveFont(Font.PLAIN, 13f));
+        table.setSelectionBackground(new Color(210, 222, 255));
+        table.setSelectionForeground(HEADER_TEXT);
+
+        JTableHeader header = table.getTableHeader();
+        header.setReorderingAllowed(false);
+        header.setFont(header.getFont().deriveFont(Font.BOLD, 13f));
+        header.setOpaque(true);
+        header.setBackground(new Color(242, 246, 255));
+        header.setForeground(HEADER_TEXT);
+        header.setBorder(new EmptyBorder(12, 12, 12, 12));
+    }
+
+    private JScrollPane tableScroll(JTable table) {
+        JScrollPane scroll = new JScrollPane(table);
+        scroll.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(225, 230, 246), 1, true),
+                new EmptyBorder(0, 0, 0, 0)
+        ));
+        scroll.getViewport().setBackground(Color.WHITE);
+        scroll.setOpaque(false);
+        return scroll;
+    }
+
+    private JPanel actionsRow(JButton... buttons) {
+        JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
+        row.setOpaque(false);
+        for (JButton b : buttons) {
+            row.add(b);
+        }
+        return row;
+    }
+
+    private JButton primaryButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setBackground(BRAND);
+        b.setForeground(Color.WHITE);
+        b.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(42, 80, 190), 1, true),
+                new EmptyBorder(10, 20, 10, 20)
+        ));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
+    }
+
+    private JButton outlineButton(String text) {
+        JButton b = new JButton(text);
+        b.setFocusPainted(false);
+        b.setBackground(Color.WHITE);
+        b.setForeground(BRAND.darker());
+        b.setBorder(BorderFactory.createCompoundBorder(
+                new LineBorder(new Color(194, 206, 255), 1, true),
+                new EmptyBorder(10, 20, 10, 20)
+        ));
+        b.putClientProperty("JButton.buttonType", "roundRect");
+        return b;
     }
 }

--- a/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/InventoryPage.java
@@ -118,6 +118,12 @@ public class InventoryPage extends JPanel {
         });
     }
 
+    public void refreshAll() {
+        registroPanel.refreshCombos();
+        modificarPanel.refreshData();
+        eliminarPanel.refreshData();
+    }
+
     private JToggleButton pillButton(String text) {
         JToggleButton b = new JToggleButton(text.toUpperCase());
         b.setFocusPainted(false);

--- a/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
+++ b/src/main/java/ar/edu/unse/siga/ui/pages/TramiteEntradaPage.java
@@ -90,6 +90,13 @@ public class TramiteEntradaPage extends JPanel {
         installEstadoListener();
     }
 
+    public void refreshAll() {
+        SwingUtilities.invokeLater(() -> {
+            loadTableData();
+            recargarTramitesRecientesSidebar();
+        });
+    }
+
     /* ====================  Estado editable (editor + listener)  ==================== */
 
     private void installEstadoEditor() {

--- a/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
+++ b/src/main/java/ar/edu/unse/siga/ui/reportes/InformesPanel.java
@@ -675,6 +675,14 @@ public class InformesPanel extends JPanel {
         }
     }
 
+    public void refreshData() {
+        reloadMetrics();
+        runQueryInventario();
+        loadTableDataTramites();
+        loadTableDataMovimientos();
+        loadRetirosRecientes();
+    }
+
     private void runQueryInventario() {
         modelInv.setRowCount(0);
         lblTotalStockMinimo.setText("0");
@@ -750,7 +758,7 @@ public class InformesPanel extends JPanel {
     }
 
     private boolean matchesEstado(Insumo insumo, String filtro) {
-        if (filtro == null || filtro.equalsIgnoreCase("Todos")) {
+        if (isTodos(filtro) || (filtro != null && filtro.trim().isEmpty())) {
             return true;
         }
         String estado = normalizeEstado(insumo.getEstado());
@@ -764,14 +772,15 @@ public class InformesPanel extends JPanel {
     }
 
     private boolean matchesTipo(Insumo insumo, String filtro) {
-        if (filtro == null || filtro.equalsIgnoreCase("Todos")) {
+        if (isTodos(filtro) || (filtro != null && filtro.trim().isEmpty())) {
             return true;
         }
+        String criterio = filtro.trim().toUpperCase(Locale.ROOT);
         String tipo = normalizeTipo(insumo.getTipo());
-        if (filtro.equalsIgnoreCase("Insumos")) {
+        if (criterio.startsWith("INS")) {
             return "INSUMO".equals(tipo);
         }
-        if (filtro.equalsIgnoreCase("Bienes")) {
+        if (criterio.startsWith("BIE")) {
             return "BIEN".equals(tipo);
         }
         return true;
@@ -847,8 +856,8 @@ public class InformesPanel extends JPanel {
                 .map(r -> normalizeTipo(r.insumo.getTipo()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        boolean dividirEstado = estadoSel != null && estadoSel.equalsIgnoreCase("Todos") && estados.size() > 1;
-        boolean dividirTipo = tipoSel != null && tipoSel.equalsIgnoreCase("Todos") && tipos.size() > 1;
+        boolean dividirEstado = isTodos(estadoSel) && estados.size() > 1;
+        boolean dividirTipo = isTodos(tipoSel) && tipos.size() > 1;
 
         if (dividirEstado && dividirTipo) {
             for (String estado : estados) {

--- a/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
+++ b/src/main/java/ar/edu/unse/siga/ui/shell/ShellFrame.java
@@ -29,6 +29,7 @@ public class ShellFrame extends JFrame {
     private final JPanel cards = new JPanel(cardLayout);
     private final JLabel lblTitle = new JLabel("Inicio");
     private final JLabel lblUser = new JLabel();
+    private final JButton btnRefresh = createRefreshButton();
 
     // services
     private final InventarioService inventarioService;
@@ -45,6 +46,7 @@ public class ShellFrame extends JFrame {
     // mapa de clave de tarjeta -> botón del sidebar
     private final Map<String, NavButton> navByKey = new HashMap<>();
     private final ButtonGroup navGroup = new ButtonGroup();
+    private String currentKey = "home";
 
     public ShellFrame(InventarioService inv, TramiteService tra, AuthService auth) {
         super("SIGA-FCEyT");
@@ -167,7 +169,13 @@ public class ShellFrame extends JFrame {
         lblUser.setText((u != null ? u.getUsername() : "-")
                 + "  |  " + java.time.LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
         lblUser.setForeground(new Color(90, 110, 150));
-        header.add(lblUser, BorderLayout.EAST);
+        lblUser.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+
+        JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
+        right.setOpaque(false);
+        right.add(btnRefresh);
+        right.add(lblUser);
+        header.add(right, BorderLayout.EAST);
         return header;
     }
 
@@ -274,6 +282,7 @@ public class ShellFrame extends JFrame {
     private void showCard(String key, String title) {
         cardLayout.show(cards, key);
         lblTitle.setText(title);
+        currentKey = key;
 
         // marcar seleccionado el botón correspondiente
         for (Map.Entry<String, NavButton> e : navByKey.entrySet()) {
@@ -294,5 +303,54 @@ public class ShellFrame extends JFrame {
 
     private void addPage(String key, Component c) {
         cards.add(c, key);
+    }
+
+    private JButton createRefreshButton() {
+        JButton btn = new JButton("Refrescar");
+        btn.setFocusPainted(false);
+        btn.setBackground(new Color(58, 96, 224));
+        btn.setForeground(Color.WHITE);
+        btn.setBorder(BorderFactory.createEmptyBorder(8, 18, 8, 18));
+        btn.putClientProperty("JButton.buttonType", "roundRect");
+        btn.addActionListener(e -> refreshCurrentPage());
+        return btn;
+    }
+
+    private void refreshCurrentPage() {
+        switch (currentKey) {
+            case "home" -> {
+                if (homePage != null) {
+                    homePage.refreshMetrics();
+                    homePage.recargarTramitesRecientes();
+                }
+            }
+            case "inventario" -> {
+                if (inventoryPage != null) {
+                    inventoryPage.refreshAll();
+                }
+            }
+            case "movimientos" -> {
+                if (movimientosPage != null) {
+                    movimientosPage.refreshInsumos();
+                }
+            }
+            case "tramites" -> {
+                if (tramitesPage != null) {
+                    tramitesPage.refreshAll();
+                }
+            }
+            case "reportes" -> {
+                if (informesPanel != null) {
+                    informesPanel.refreshData();
+                }
+            }
+            case "gestiones" -> {
+                if (gestionesPage != null) {
+                    gestionesPage.refreshData();
+                }
+            }
+            default -> {
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the inventory report preview honours the "Todos" type filter and expose a refresh hook for the module
- add a top-level refresh button that reloads data for each section and surface the required refresh helpers
- restyle the Gestiones administration tabs with the shared card aesthetic and actionable buttons

## Testing
- mvn -q -DskipTests compile *(fails: Maven Central returns 403 for junit-bom)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a15036488321981b5e68b18abd43)